### PR TITLE
Hotfix for Crash de.tum.informatics.www1.artemis.native_app.feature.metis.shared.db.MetisDao_Impl$42.call

### DIFF
--- a/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/db/AppDatabase.kt
+++ b/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/db/AppDatabase.kt
@@ -1,6 +1,5 @@
 package de.tum.informatics.www1.artemis.native_app.android.db
 
-import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
@@ -31,9 +30,6 @@ import de.tum.informatics.www1.artemis.native_app.feature.push.communication_not
     ],
     exportSchema = true,
     version = 10,
-    autoMigrations = [
-        AutoMigration(from = 9, to = 10)
-    ]
 )
 @TypeConverters(RoomTypeConverters::class)
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/db/AppDatabase.kt
+++ b/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/db/AppDatabase.kt
@@ -1,5 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.android.db
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
@@ -29,7 +30,10 @@ import de.tum.informatics.www1.artemis.native_app.feature.push.communication_not
         CommunicationMessageEntity::class
     ],
     exportSchema = true,
-    version = 9
+    version = 10,
+    autoMigrations = [
+        AutoMigration(from = 9, to = 10)
+    ]
 )
 @TypeConverters(RoomTypeConverters::class)
 abstract class AppDatabase : RoomDatabase() {


### PR DESCRIPTION
Increase database version to prevent app crashes introduced by last hotfix (AppVersion 467, Schema update in [this commit](https://github.com/ls1intum/artemis-android/commit/5a185d515746fb7f1ccdf3bf3eedc771f1be843f))

Error in GooglePlayConsole:
`de.tum.informatics.www1.artemis.native_app.feature.metis.shared.db.MetisDao_Impl$42.call`