### PR TITLE
`Chore`: Fix End To End Tests Containers

### DIFF
--- a/docker/artemis.yml
+++ b/docker/artemis.yml
@@ -9,6 +9,8 @@ services:
     # https://docs.artemis.cit.tum.de/dev/setup/#
     image: ghcr.io/ls1intum/artemis:latest
     pull_policy: always
+    volumes:
+      - artemis-data:/opt/artemis/data
     # system environments are the default way for custom configuration overrides in the containerized artemis setups
     # either add them in the environments or env_file section (alternative to application-local.yml)
     env_file:
@@ -31,3 +33,7 @@ networks:
   artemis:
     driver: "bridge"
     name: artemis
+
+volumes:
+  artemis-data:
+    name: artemis-data

--- a/docker/artemis_e2e_config.env
+++ b/docker/artemis_e2e_config.env
@@ -1,4 +1,4 @@
-SPRING_PROFILES_ACTIVE="artemis,scheduling,dev,docker"
+SPRING_PROFILES_ACTIVE="artemis,scheduling,dev,docker,core"
 
 SPRING_DATASOURCE_USERNAME="root"
 SPRING_DATASOURCE_PASSWORD=""

--- a/docker/e2e-tests.yml
+++ b/docker/e2e-tests.yml
@@ -37,3 +37,9 @@ networks:
   artemis:
     driver: "bridge"
     name: artemis
+
+volumes:
+  artemis-mysql-data:
+    name: artemis-mysql-data
+  artemis-data:
+    name: artemis-data

--- a/docker/mysql.yml
+++ b/docker/mysql.yml
@@ -6,15 +6,19 @@ services:
   mysql:
     container_name: artemis-mysql
     image: docker.io/library/mysql:9.0.1
+    volumes:
+      - artemis-mysql-data:/var/lib/mysql
     # DO NOT use this default file for production systems!
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_DATABASE: "Artemis"
+    ports:
+      - "127.0.0.1:3306:3306"
     # expose the port to make it reachable docker internally even if the external port mapping changes
     expose:
       - "3306"
-    command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8mb4 --collation-server=utf8mb4_unicode_ci --explicit_defaults_for_timestamp
+    command: mysqld --lower_case_table_names=1 --tls-version='' --character_set_server=utf8mb4 --collation-server=utf8mb4_unicode_ci --explicit_defaults_for_timestamp --max_connections=100000
     # mbind: Operation not permitted workaround for docker compose (see https://github.com/docker-library/mysql/issues/303)
     cap_add:
       - SYS_NICE  # CAP_SYS_NICE
@@ -31,3 +35,7 @@ networks:
   artemis:
     driver: "bridge"
     name: artemis
+
+volumes:
+  artemis-mysql-data:
+    name: artemis-mysql-data

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,10 @@ This project is configured to support multiple [flavor dimensions](https://devel
 ## Tests
 We use both unit tests and end-to-end integration tests. Before running the end-to-end tests, consider the licenses section in this readme.
 - To run the unit tests, execute `./gradlew test -Dskip.unit-tests=false -Dskip.e2e=true -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true`
-- To run the end-to-end tests, execute `docker compose -f docker/e2e-tests.yml up artemis-android-e2e`
+- To run the end-to-end tests, first start artemis locally in docker: 
+  - `docker compose -f docker/e2e-tests.yml up artemis-app-setup`
+  - `./gradlew test -Dskip.unit-tests=true -Dskip.e2e=false -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true`
+
 
 ## Play store screenshots
 Screenshots can be generated using preview-composables in the `debug` source sets. They are annotated with `@PlayStoreScreenshots`. To get the screenshots, right click the rendered preview


### PR DESCRIPTION
- Fixed end to end test setup locally to get them running again
- Updated README on how to start the end to end tests locally