### PR TITLE
Fix ConnectionTimout in debug mode

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 
     implementation(libs.androidx.dataStore.preferences)
 
-    debugImplementation(libs.ktor.client.cio)
+    testImplementation(libs.ktor.client.cio)
 
     testImplementation(project(":core:common-test"))
     testImplementation(project(":core:data-test"))


### PR DESCRIPTION
Removing the ktor-client-cio for debug, because it caused ConnectionTimeout Errors after the 100th request.
This closes the problem described in issue  #69. Note that this problem did not occur on the release version of the app.

I ensured that no new tests fail because of this change by running the E2E tests locally.