### PR TITLE
Fix RegisterViewModel initialization

### DIFF
--- a/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/login/LoginViewModel.kt
+++ b/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/login/LoginViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * View model to handle the login process.
@@ -33,7 +34,7 @@ class LoginViewModel(
     serverConfigurationService: ServerConfigurationService,
     serverProfileInfoService: ServerProfileInfoService,
     networkStatusProvider: NetworkStatusProvider,
-    private val coroutineContext: CoroutineContext
+    private val coroutineContext: CoroutineContext = EmptyCoroutineContext
 ) : BaseAccountViewModel(serverConfigurationService, networkStatusProvider, serverProfileInfoService) {
 
     companion object {

--- a/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/login_module.kt
+++ b/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/login_module.kt
@@ -17,7 +17,6 @@ import org.koin.androidx.viewmodel.dsl.viewModel
 
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
-import kotlin.coroutines.EmptyCoroutineContext
 
 val loginModule = module {
     viewModelOf(::AccountViewModel)
@@ -29,11 +28,18 @@ val loginModule = module {
             get(),
             get(),
             get(),
-            get(),
-            EmptyCoroutineContext
+            get()
         )
     }
-    viewModelOf(::RegisterViewModel)
+    viewModel {
+        RegisterViewModel(
+            get(),
+            get(),
+            get(),
+            get(),
+            get()
+        )
+    }
     viewModelOf(::CustomInstanceSelectionViewModel)
     viewModel { params -> Saml2LoginViewModel(params.get(), get(), get(), get(), get()) }
 

--- a/feature/login/src/test/java/de/tum/informatics/www1/artemis/native_app/feature/login/login_moduleTest.kt
+++ b/feature/login/src/test/java/de/tum/informatics/www1/artemis/native_app/feature/login/login_moduleTest.kt
@@ -1,0 +1,89 @@
+package de.tum.informatics.www1.artemis.native_app.feature.login
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.lifecycle.ViewModel
+import androidx.test.platform.app.InstrumentationRegistry
+import de.tum.informatics.www1.artemis.native_app.core.common.test.DefaultTestTimeoutMillis
+import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
+import de.tum.informatics.www1.artemis.native_app.core.test.BaseComposeTest
+import de.tum.informatics.www1.artemis.native_app.core.test.coreTestModules
+import de.tum.informatics.www1.artemis.native_app.feature.login.custom_instance_selection.CustomInstanceSelectionViewModel
+import de.tum.informatics.www1.artemis.native_app.feature.login.login.LoginViewModel
+import de.tum.informatics.www1.artemis.native_app.feature.login.register.RegisterViewModel
+import de.tum.informatics.www1.artemis.native_app.feature.login.saml2_login.Saml2LoginViewModel
+import de.tum.informatics.www1.artemis.native_app.feature.push.pushModule
+import org.junit.Rule
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.LocalKoinApplication
+import org.koin.compose.LocalKoinScope
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.parameter.parametersOf
+import org.koin.mp.KoinPlatformTools
+import org.koin.test.KoinTestRule
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+
+@RunWith(RobolectricTestRunner::class)
+@Category(UnitTest::class)
+internal class login_moduleTest : BaseComposeTest() {
+
+    @get:Rule
+    val koinTestRule = KoinTestRule.create {
+        androidContext(InstrumentationRegistry.getInstrumentation().context)
+
+        modules(coreTestModules)
+        modules(loginModule, pushModule)
+    }
+
+
+    @Test(timeout = DefaultTestTimeoutMillis)
+    fun `the loginModule initializes AccountViewModel without errors`() {
+        composeTestRule.testViewModelInitialization<AccountViewModel>()
+    }
+
+    @Test(timeout = DefaultTestTimeoutMillis)
+    fun `the loginModule initializes LoginViewModel without errors`() {
+        composeTestRule.testViewModelInitialization<LoginViewModel>()
+    }
+
+    @Test(timeout = DefaultTestTimeoutMillis)
+    fun `the loginModule initializes RegisterViewModel without errors`() {
+        composeTestRule.testViewModelInitialization<RegisterViewModel>()
+    }
+
+    @Test(timeout = DefaultTestTimeoutMillis)
+    fun `the loginModule initializes CustomInstanceSelectionViewModel without errors`() {
+        composeTestRule.testViewModelInitialization<CustomInstanceSelectionViewModel>()
+    }
+
+    @Test(timeout = DefaultTestTimeoutMillis)
+    fun `the loginModule initializes Saml2LoginViewModel without errors`() {
+        composeTestRule.testViewModelInitialization<Saml2LoginViewModel> {
+            parametersOf(true)  // rememberMe
+        }
+    }
+
+
+    @OptIn(KoinInternalApi::class)
+    private inline fun <reified T: ViewModel> ComposeContentTestRule.testViewModelInitialization(
+        noinline parameters: ParametersDefinition? = null
+    ) {
+        setContent {
+            // This is a workaround to make koin work in tests.
+            // See: https://github.com/InsertKoinIO/koin/issues/1557#issue-1660665501
+            CompositionLocalProvider(
+                LocalKoinScope provides KoinPlatformTools.defaultContext()
+                    .get().scopeRegistry.rootScope,
+                LocalKoinApplication provides KoinPlatformTools.defaultContext().get()
+            ) {
+                koinViewModel<T>(parameters = parameters)
+            }
+        }
+    }
+}


### PR DESCRIPTION
While working on another ticket, I found that the app crashes when navigating to the register screen.

I created unit tests that ensure that there are no error when initializing the ViewModels.

### How to manually test
- If you are currently logged into the app, log out by tapping the settings / gear icon and choose "Logout"
- Press "not your university"
- Choose "TUM test-server-2"
- Press register -> previously the app crashed here