### PR TITLE
Fix Lecture and Exercises Links to be opened inside the app

### DIFF
--- a/core/common/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/common/markdown/ArtemisMarkdownTransformer.kt
+++ b/core/common/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/common/markdown/ArtemisMarkdownTransformer.kt
@@ -21,7 +21,7 @@ abstract class ArtemisMarkdownTransformer {
     }
 
     private val exerciseMarkdownPattern =
-        "\\[(text|quiz|lecture|modeling|file-upload|programing)](.*)\\(((?:/|\\w|\\d)+)\\)\\[/\\1]".toRegex()
+        "\\[(text|quiz|lecture|modeling|file-upload|programming)](.*)\\(((?:/|\\w|\\d)+)\\)\\[/\\1]".toRegex()
     private val userMarkdownPattern = "\\[user](.*?)\\((.*?)\\)\\[/user]".toRegex()
     private val channelMarkdownPattern = "\\[channel](.*?)\\((\\d+?)\\)\\[/channel]".toRegex()
 

--- a/core/common/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/common/markdown/PostArtemisMarkdownTransformer.kt
+++ b/core/common/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/common/markdown/PostArtemisMarkdownTransformer.kt
@@ -2,7 +2,7 @@ package de.tum.informatics.www1.artemis.native_app.core.common.markdown
 
 class PostArtemisMarkdownTransformer(val serverUrl: String, val courseId: Long) : ArtemisMarkdownTransformer() {
     override fun transformExerciseMarkdown(title: String, url: String): String {
-        return "[$title]($serverUrl$url)"
+        return "[$title](artemis:/$url)"
     }
 
     override fun transformUserMentionMarkdown(text: String, fullName: String, userName: String): String = "[@$fullName](artemis://courses/$courseId/messages?username=$userName)"


### PR DESCRIPTION
### Description
The PostArtemisMarkdownTransformer has been modified to open lecture and exercises link sent in the chat inside the app instead of the browser. 
This PR is a follow-up PR to fix #73.
