### PR TITLE
`Chore`: Add run configurations for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,32 @@
+# IntelliJ IDEA files
 *.iml
-.gradle
-.idea
+.idea/*
+!.idea/runConfigurations/
+
+# MacOS files
 .DS_Store
-build
-captures
+
+# Gradle files
+.gradle
 .externalNativeBuild
 .cxx
 local.properties
+
+# Build output
+build
+captures
+*.aab
+*.apk
+/app/release/output-metadata.json
+
+# Keystore files
 *.jks
 passwords
 *.pepk
 keystore.properties
-*.aab
-*.apk
-/app/release/output-metadata.json
+
+# Test outputs
 test-outputs
+
+# Service credentials
 serviceCredentials.json

--- a/.idea/runConfigurations/Docker_for_E2E_Tests.xml
+++ b/.idea/runConfigurations/Docker_for_E2E_Tests.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Docker for E2E Tests" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="envFilePath" value="" />
+        <option name="sourceFilePath" value="docker/e2e-tests.yml" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/E2E_Tests.xml
+++ b/.idea/runConfigurations/E2E_Tests.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="E2E Tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--max-workers=4 -Dskip.unit-tests=true -Dskip.e2e=false -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/E2E_Tests.xml
+++ b/.idea/runConfigurations/E2E_Tests.xml
@@ -18,7 +18,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
-    <RunAsTest>false</RunAsTest>
+    <RunAsTest>true</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/.idea/runConfigurations/Unit_Tests_.xml
+++ b/.idea/runConfigurations/Unit_Tests_.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unit Tests " type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--max-workers=4 -Dskip.unit-tests=false -Dskip.e2e=true -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Unit_Tests_.xml
+++ b/.idea/runConfigurations/Unit_Tests_.xml
@@ -18,7 +18,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
-    <RunAsTest>false</RunAsTest>
+    <RunAsTest>true</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,8 @@ We use both unit tests and end-to-end integration tests. Before running the end-
 - To run the unit tests, execute `./gradlew test -Dskip.unit-tests=false -Dskip.e2e=true -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true`
 - To run the end-to-end tests, execute `docker compose -f docker/e2e-tests.yml up artemis-android-e2e`
 
+For AndroidStudio, there are also preconfigured run configurations available. 
+
 ## Play store screenshots
 Screenshots can be generated using preview-composables in the `debug` source sets. They are annotated with `@PlayStoreScreenshots`. To get the screenshots, right click the rendered preview
 in AndroidStudio and select copy-image.


### PR DESCRIPTION
- Added run configurations for unit and e2e tests, that can directly be accessed from within Android Studio
- Updated the readme
- Restructured gitignore + add run configurations to git

![grafik](https://github.com/user-attachments/assets/859b7586-fa4b-4e67-9377-a09888f37b5d)
