### PR TITLE
Fix crash when searching inside channel

### DIFF
--- a/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/defaults/ArtemisInstances.kt
+++ b/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/defaults/ArtemisInstances.kt
@@ -31,7 +31,7 @@ object ArtemisInstances {
     )
 
     private val TumTs1 = ArtemisInstance(
-        host = "artemis-test1.artemis.in.tum.de",
+        host = "artemis-test1.artemis.cit.tum.de",
         name = R.string.artemis_instance_tum_test_server_1,
         type = ArtemisInstance.Type.TEST
     )

--- a/feature/metis-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metistest/MetisServiceStub.kt
+++ b/feature/metis-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metistest/MetisServiceStub.kt
@@ -9,13 +9,9 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.d
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
-class MetisServiceStub : MetisService {
-
-    private var posts: List<StandalonePost> = emptyList()
-
-    fun setPosts(posts: List<StandalonePost>) {
-        this.posts = posts
-    }
+class MetisServiceStub(
+    var posts: List<StandalonePost> = emptyList()
+): MetisService {
 
     override suspend fun getPosts(
         standalonePostsContext: MetisService.StandalonePostsContext,

--- a/feature/metis-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metistest/MetisServiceStub.kt
+++ b/feature/metis-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metistest/MetisServiceStub.kt
@@ -1,0 +1,42 @@
+package de.tum.informatics.www1.artemis.native_app.feature.metistest
+
+import de.tum.informatics.www1.artemis.native_app.core.data.NetworkResponse
+import de.tum.informatics.www1.artemis.native_app.core.websocket.WebsocketProvider
+import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisService
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisPostDTO
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.StandalonePost
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class MetisServiceStub : MetisService {
+
+    private var posts: List<StandalonePost> = emptyList()
+
+    fun setPosts(posts: List<StandalonePost>) {
+        this.posts = posts
+    }
+
+    override suspend fun getPosts(
+        standalonePostsContext: MetisService.StandalonePostsContext,
+        pageSize: Int,
+        pageNum: Int,
+        authToken: String,
+        serverUrl: String
+    ): NetworkResponse<List<StandalonePost>> {
+        return NetworkResponse.Response(posts)
+    }
+
+    override suspend fun getPost(
+        metisContext: MetisContext,
+        serverSidePostId: Long,
+        serverUrl: String,
+        authToken: String
+    ): NetworkResponse<StandalonePost> {
+        return NetworkResponse.Response(posts.first())
+    }
+
+    override fun subscribeToPostUpdates(metisContext: MetisContext): Flow<WebsocketProvider.WebsocketData<MetisPostDTO>> {
+        return flowOf()
+    }
+}

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSource.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSource.kt
@@ -33,7 +33,7 @@ class MetisSearchPagingSource(
                 mapSuccess = { loadedPosts ->
                     // Currently the server returns duplicate posts when searching for posts. This
                     // caused a crash in the UI.
-                    // Here is the related issue on Github: https://github.com/ls1intum/Artemis/issues/9709
+                    // TODO: https://github.com/ls1intum/artemis-android/issues/99
                     val filteredPosts = loadedPosts.distinctBy { it.id }
                     LoadResult.Page(
                         data = filteredPosts,

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSource.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSource.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingState
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.StandalonePost
 
+
 class MetisSearchPagingSource(
     private val metisService: MetisService,
     private val context: MetisService.StandalonePostsContext,
@@ -30,8 +31,12 @@ class MetisSearchPagingSource(
         )
             .map(
                 mapSuccess = { loadedPosts ->
+                    // Currently the server returns duplicate posts when searching for posts. This
+                    // caused a crash in the UI.
+                    // Here is the related issue on Github: https://github.com/ls1intum/Artemis/issues/9709
+                    val filteredPosts = loadedPosts.distinctBy { it.id }
                     LoadResult.Page(
-                        data = loadedPosts,
+                        data = filteredPosts,
                         prevKey = if (page > 0) page - 1 else null,
                         nextKey = if (loadedPosts.size == params.loadSize) page + 1 else null
                     )

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSourceTest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSourceTest.kt
@@ -1,0 +1,77 @@
+package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.chatlist
+
+import androidx.paging.PagingSource
+import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
+import de.tum.informatics.www1.artemis.native_app.core.model.account.User
+import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisService
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.StandalonePost
+import de.tum.informatics.www1.artemis.native_app.feature.metistest.MetisServiceStub
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+
+@Category(UnitTest::class)
+@RunWith(RobolectricTestRunner::class)
+class MetisSearchPagingSourceTest {
+
+    private lateinit var sut: MetisSearchPagingSource
+    private val metisServiceStub = MetisServiceStub()
+
+    @Before
+    fun setup() {
+        sut = MetisSearchPagingSource(
+            metisService = metisServiceStub,
+            context = MetisService.StandalonePostsContext(
+                metisContext = MetisContext.Course(1),
+                filter = emptyList(),
+                query = null
+            ),
+            authToken = "token",
+            serverUrl = "url"
+        )
+    }
+
+    @Test
+    fun `GIVEN the metisService returns duplicated posts WHEN calling the load method THEN only unique posts are returned`() = runTest {
+        // GIVEN
+        val post1 = StandalonePost(
+            id = 1,
+            content = "content",
+            author = User(),
+            creationDate = Clock.System.now(),
+            displayPriority = null,
+            tags = emptyList()
+        )
+
+        val post2 = StandalonePost(
+            id = 2,
+            content = "content",
+            author = User(),
+            creationDate = Clock.System.now(),
+            displayPriority = null,
+            tags = emptyList()
+        )
+
+        val posts = listOf(post1, post2, post1)
+        metisServiceStub.setPosts(posts)
+
+        // WHEN
+        val result = sut.load(PagingSource.LoadParams.Refresh(0, 10, false))
+
+        // THEN
+        assertTrue(result is PagingSource.LoadResult.Page)
+        val page = result as PagingSource.LoadResult.Page<Int, StandalonePost>
+        assertEquals(2, page.data.size)
+        assertEquals(post1, page.data[0])
+        assertEquals(post2, page.data[1])
+    }
+
+}

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSourceTest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSourceTest.kt
@@ -2,13 +2,11 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 
 import androidx.paging.PagingSource
 import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
-import de.tum.informatics.www1.artemis.native_app.core.model.account.User
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.StandalonePost
 import de.tum.informatics.www1.artemis.native_app.feature.metistest.MetisServiceStub
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -36,23 +34,8 @@ class MetisSearchPagingSourceTest {
     @Test
     fun `test GIVEN the metisService returns duplicated posts WHEN calling the load method THEN only unique posts are returned`() = runTest {
         // GIVEN
-        val post1 = StandalonePost(
-            id = 1,
-            content = "content",
-            author = User(),
-            creationDate = Clock.System.now(),
-            displayPriority = null,
-            tags = emptyList()
-        )
-
-        val post2 = StandalonePost(
-            id = 2,
-            content = "content",
-            author = User(),
-            creationDate = Clock.System.now(),
-            displayPriority = null,
-            tags = emptyList()
-        )
+        val post1 = StandalonePost(id = 1)
+        val post2 = StandalonePost(id = 2)
 
         val posts = listOf(post1, post2, post1)
         metisServiceStub.posts = posts

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSourceTest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisSearchPagingSourceTest.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
@@ -22,25 +21,20 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class MetisSearchPagingSourceTest {
 
-    private lateinit var sut: MetisSearchPagingSource
     private val metisServiceStub = MetisServiceStub()
-
-    @Before
-    fun setup() {
-        sut = MetisSearchPagingSource(
-            metisService = metisServiceStub,
-            context = MetisService.StandalonePostsContext(
-                metisContext = MetisContext.Course(1),
-                filter = emptyList(),
-                query = null
-            ),
-            authToken = "token",
-            serverUrl = "url"
-        )
-    }
+    private val sut: MetisSearchPagingSource = MetisSearchPagingSource(
+        metisService = metisServiceStub,
+        context = MetisService.StandalonePostsContext(
+            metisContext = MetisContext.Course(1),
+            filter = emptyList(),
+            query = null
+        ),
+        authToken = "token",
+        serverUrl = "url"
+    )
 
     @Test
-    fun `GIVEN the metisService returns duplicated posts WHEN calling the load method THEN only unique posts are returned`() = runTest {
+    fun `test GIVEN the metisService returns duplicated posts WHEN calling the load method THEN only unique posts are returned`() = runTest {
         // GIVEN
         val post1 = StandalonePost(
             id = 1,
@@ -61,7 +55,7 @@ class MetisSearchPagingSourceTest {
         )
 
         val posts = listOf(post1, post2, post1)
-        metisServiceStub.setPosts(posts)
+        metisServiceStub.posts = posts
 
         // WHEN
         val result = sut.load(PagingSource.LoadParams.Refresh(0, 10, false))


### PR DESCRIPTION
### Problem
When searching in a channel the server currently sometimes returns posts multiple times. This happens eg if a post has multiple answers in its thread. Conveniently, there was just opened an issue about this in the Artemis repo: https://github.com/ls1intum/Artemis/issues/9709

This caused the Android app to crash due to violation of unique key constraints in the LazyList.

### Changes
- Filtering out duplicated posts 
- Added tests to ensure functionality
- Updated URL for TestServer1

### Testing
Eg go to TS1
-> Practical Course: Interactive Learning SS24 
-> #random 
-> Search for "me" 
-> The app does not crash


This closes issue #95.