### PR TITLE
`Hotfix`: Fix post creation of MetisThreadUI to create replies instead of posts

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/thread/MetisThreadUi.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/thread/MetisThreadUi.kt
@@ -100,7 +100,7 @@ internal fun MetisThreadUi(
         serverUrl = serverUrl,
         emojiService = koinInject(),
         clientId = clientId,
-        onCreatePost = viewModel::createPost,
+        onCreatePost = viewModel::createReply,
         onEditPost = { post, newText ->
             val parentPost = postDataState.orNull()
 


### PR DESCRIPTION
### Description
This PR is a **hotfix** that fixes an issue, which caused replies in the thread view not to be created correctly. Instead of calling the createReply function the createPost function of ConversationViewModel was called, leading to a post creation instead of a reply creation.
This bug only affects `develop` and has been introduced by the change of MetisThreadUI in #59.