### PR TITLE
`Chore`: Display server url in settings

### DIFF
--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
@@ -207,6 +207,7 @@ private fun SettingsScreen(
             AboutSection(
                 modifier = Modifier.fillMaxWidth(),
                 hasUserSelectedInstance = hasUserSelectedInstance,
+                serverUrl = serverUrl,
                 onOpenPrivacyPolicy = {
                     val link = URLBuilder(serverUrl).appendPathSegments("privacy").buildString()
 
@@ -334,6 +335,7 @@ private fun NotificationSection(modifier: Modifier, onOpenNotificationSettings: 
 private fun AboutSection(
     modifier: Modifier,
     hasUserSelectedInstance: Boolean,
+    serverUrl: String,
     onRequestSelectServerInstance: () -> Unit,
     onOpenPrivacyPolicy: () -> Unit,
     onOpenImprint: () -> Unit,
@@ -352,6 +354,12 @@ private fun AboutSection(
         }
 
         if (hasUserSelectedInstance) {
+            PreferenceEntry(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.settings_server_url, serverUrl),
+                onClick = {}
+            )
+
             PreferenceEntry(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.settings_about_privacy_policy),

--- a/feature/settings/src/main/res/values/settings_strings.xml
+++ b/feature/settings/src/main/res/values/settings_strings.xml
@@ -12,6 +12,7 @@
 
     <string name="settings_about_section">About</string>
     <string name="settings_server_specifics_information">Imprint and privacy policy depend on the server you have currently selected.</string>
+    <string name="settings_server_url">Server URL: %1$s</string>
     <string name="settings_server_specifics_unavailable">Imprint and privacy policy are unavailable as you have not yet selected a server instance. Please select a server instance to view their privacy policy and imprint.</string>
     <string name="settings_server_specifics_unavailable_select_instance_button">Select instance</string>
     <string name="settings_about_privacy_policy">Privacy policy</string>


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
Currently it is very hard / not directly possible to see what server one is currently logged in to.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Display the server url in the settings

**Out of scope**
I know that the layout is not optimal atm, but I think the whole settings section should be overhauled in  a separate PR.


### Steps for testing
- Open settings
- Scroll to About section
- See server url

### Screenshots
![image](https://github.com/user-attachments/assets/1c9a92e5-14ab-4214-8513-7dc0e3cd910d)
