### PR TITLE
`Bugfix`: Fix post insertion for live created posts 

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceImpl.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceImpl.kt
@@ -146,12 +146,13 @@ internal class MetisStorageServiceImpl(
             serverId: String,
             clientSidePostId: String,
             serverSidePostId: Long?,
+            conversationId: Long?,
             postingType: BasePostingEntity.PostingType
         ): MetisPostContextEntity =
             MetisPostContextEntity(
                 serverId = serverId,
                 courseId = courseId,
-                conversationId = conversationId,
+                conversationId = conversationId ?: this.conversationId,
                 serverPostId = serverSidePostId,
                 clientPostId = clientSidePostId,
                 postingType = postingType
@@ -458,11 +459,13 @@ internal class MetisStorageServiceImpl(
         metisDao.insertOrUpdateUser(postingAuthor)
 
         val standalonePostId = sp.id
+        val conversationId = sp.conversation?.id
         val postMetisContext =
             metisContext.toPostMetisContext(
                 serverId = host,
                 clientSidePostId = clientSidePostId,
                 serverSidePostId = standalonePostId,
+                conversationId = conversationId,
                 postingType = BasePostingEntity.PostingType.STANDALONE
             )
 
@@ -568,6 +571,7 @@ internal class MetisStorageServiceImpl(
                     serverId = host,
                     clientSidePostId = answerPostClientSidePostId,
                     serverSidePostId = answerPostId,
+                    conversationId = null,
                     postingType = BasePostingEntity.PostingType.ANSWER
                 )
             )


### PR DESCRIPTION
### Problem Description
When having a channel open and receiving a post from another channel the post gets saved into the currently opened channel. This PR fixes this issue by inserting the correct conversationId into the database. This PR fixes #115 

### Changes
MetisStorageService has been updated to save the correct conversationId for the post.

### Steps for testing
1. Open a channel on the app
2. Send a message in a public channel on the website
3. Check if the message has not been saved in the currently opened channel on the app but in the correct one.
