### PR TITLE
`Bugfix`: Fix manual refresh for post updates

### DIFF
--- a/core/core-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/test/TestWebsocketProvider.kt
+++ b/core/core-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/test/TestWebsocketProvider.kt
@@ -21,12 +21,12 @@ class TestWebsocketProvider : WebsocketProvider {
     override val isConnected: Flow<Boolean> = flowOf(true)
 
     override fun <T : Any> subscribe(
-        channel: String,
+        topic: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<WebsocketProvider.WebsocketData<T>> = flowOf(WebsocketProvider.WebsocketData.Subscribe())
 
     override fun <T : Any> subscribeMessage(
-        channel: String,
+        topic: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<T> = emptyFlow()
 

--- a/core/websocket/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/core/websocket/WebsocketProviderStub.kt
+++ b/core/websocket/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/core/websocket/WebsocketProviderStub.kt
@@ -15,12 +15,12 @@ class WebsocketProviderStub : WebsocketProvider {
     override val isConnected: Flow<Boolean> = flowOf(true)
 
     override fun <T : Any> subscribe(
-        channel: String,
+        topic: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<WebsocketProvider.WebsocketData<T>> = emptyFlow()
 
     override fun <T : Any> subscribeMessage(
-        channel: String,
+        topic: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<T> = emptyFlow()
 

--- a/core/websocket/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/websocket/WebsocketProvider.kt
+++ b/core/websocket/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/websocket/WebsocketProvider.kt
@@ -19,12 +19,12 @@ interface WebsocketProvider {
      * Performs automatic reconnects.
      */
     fun <T : Any> subscribe(
-        channel: String,
+        topic: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<WebsocketData<T>>
 
     fun <T : Any> subscribeMessage(
-        channel: String,
+        topic: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<T>
 

--- a/core/websocket/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/websocket/impl/WebsocketProviderImpl.kt
+++ b/core/websocket/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/websocket/impl/WebsocketProviderImpl.kt
@@ -199,7 +199,7 @@ class WebsocketProviderImpl(
      * The given flow can only be subscribed to once.
      */
     override fun <T : Any> subscribe(
-        channel: String,
+        topic: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<WebsocketProvider.WebsocketData<T>> {
         return session
@@ -207,20 +207,20 @@ class WebsocketProviderImpl(
                 val flow: Flow<WebsocketProvider.WebsocketData<T>> = flow {
                     emitAll(
                         currentSession.subscribe(
-                            StompSubscribeHeaders(destination = channel),
+                            StompSubscribeHeaders(destination = topic),
                             deserializer
                         )
                     )
                 }
                     .onStart {
-                        Log.d(TAG, "subscribe! $channel")
+                        Log.d(TAG, "subscribe! $topic")
                         emit(WebsocketProvider.WebsocketData.Subscribe())
                     }
                     .onCompletion {
-                        Log.d(TAG, "unsubscribe! $channel")
+                        Log.d(TAG, "unsubscribe! $topic")
                     }
                     .catch { e ->
-                        Log.d(TAG, "Subscription $channel reported error: ${e.localizedMessage}")
+                        Log.d(TAG, "Subscription $topic reported error: ${e.localizedMessage}")
                     }
                     .map {
                         WebsocketProvider.WebsocketData.Message(it)
@@ -247,10 +247,10 @@ class WebsocketProviderImpl(
     }
 
     override fun <T : Any> subscribeMessage(
-        channel: String,
+        topic: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<T> {
-        return subscribe(channel, deserializer).mapNotNull {
+        return subscribe(topic, deserializer).mapNotNull {
             when (it) {
                 is WebsocketProvider.WebsocketData.Message -> it.message
                 else -> null

--- a/core/websocket/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/websocket/impl/WebsocketTopic.kt
+++ b/core/websocket/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/websocket/impl/WebsocketTopic.kt
@@ -1,0 +1,26 @@
+package de.tum.informatics.www1.artemis.native_app.core.websocket.impl
+
+object WebsocketTopic {
+
+    /**
+     * Returns the topic for conversation updates for a course-wide conversation.
+     */
+    fun getCourseWideConversationUpdateTopic(courseId: Long): String {
+        return "/topic/metis/courses/$courseId"
+    }
+
+    /**
+     * Returns the topic for conversation updates for a non-course-wide conversation.
+     */
+    fun getNormalConversationUpdateTopic(userId: Long): String {
+        return "/topic/user/$userId/notifications/conversations"
+    }
+
+    /**
+     * Returns the topic for conversation meta updates. This includes channel creation, deletion,
+     * and updates (like changing the channel name).
+     */
+    fun getConversationMetaUpdateTopic(courseId: Long, userId: Long): String {
+        return "/user/topic/metis/courses/$courseId/conversations/user/$userId"
+    }
+}

--- a/feature/metis-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metistest/MetisServiceStub.kt
+++ b/feature/metis-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metistest/MetisServiceStub.kt
@@ -32,7 +32,10 @@ class MetisServiceStub(
         return NetworkResponse.Response(posts.first())
     }
 
-    override fun subscribeToPostUpdates(metisContext: MetisContext): Flow<WebsocketProvider.WebsocketData<MetisPostDTO>> {
+    override fun subscribeToPostUpdates(
+        courseId: Long,
+        clientId: Long
+    ): Flow<WebsocketProvider.WebsocketData<MetisPostDTO>> {
         return flowOf()
     }
 }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/MetisService.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/MetisService.kt
@@ -34,7 +34,8 @@ interface MetisService {
     ): NetworkResponse<StandalonePost>
 
     fun subscribeToPostUpdates(
-        metisContext: MetisContext
+        courseId: Long,
+        clientId: Long,
     ): Flow<WebsocketProvider.WebsocketData<MetisPostDTO>>
 
     /**

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/impl/MetisServiceImpl.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/impl/MetisServiceImpl.kt
@@ -5,6 +5,7 @@ import de.tum.informatics.www1.artemis.native_app.core.data.cookieAuth
 import de.tum.informatics.www1.artemis.native_app.core.data.performNetworkCall
 import de.tum.informatics.www1.artemis.native_app.core.data.service.KtorProvider
 import de.tum.informatics.www1.artemis.native_app.core.websocket.WebsocketProvider
+import de.tum.informatics.www1.artemis.native_app.core.websocket.impl.WebsocketTopic
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.RESOURCE_PATH_SEGMENTS
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
@@ -153,12 +154,12 @@ internal class MetisServiceImpl(
         courseId: Long,
         clientId: Long
     ): Flow<WebsocketProvider.WebsocketData<MetisPostDTO>> {
-        val channel = "/topic/metis/courses/$courseId"
-        val channelConversationNotifications = "/topic/user/$clientId/notifications/conversations"
+        val courseWideTopic = WebsocketTopic.getCourseWideConversationUpdateTopic(courseId)
+        val normalTopic = WebsocketTopic.getNormalConversationUpdateTopic(clientId)
 
-        val flow1 = websocketProvider.subscribe(channel, MetisPostDTO.serializer())
-        val flow2 = websocketProvider.subscribe(channelConversationNotifications, MetisPostDTO.serializer())
+        val courseWideUpdates = websocketProvider.subscribe(courseWideTopic, MetisPostDTO.serializer())
+        val normalUpdates = websocketProvider.subscribe(normalTopic, MetisPostDTO.serializer())
 
-        return merge(flow1, flow2)
+        return merge(courseWideUpdates, normalUpdates)
     }
 }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
@@ -42,7 +42,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.reply.ReplyAutoCompleteHintProvider
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.thread.ConversationThreadUseCase
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisPostAction
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisCrudAction
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.StandalonePostId
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.AnswerPost
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.ConversationWebsocketDto
@@ -233,7 +233,7 @@ internal open class ConversationViewModel(
         clientId.filterSuccess()
     ) { conversationDataState, clientId ->
         websocketProvider.subscribeToConversationUpdates(clientId, metisContext.courseId)
-            .filter { it.crudAction == MetisPostAction.UPDATE }
+            .filter { it.crudAction == MetisCrudAction.UPDATE }
             .map<ConversationWebsocketDto, DataState<Conversation>> { DataState.Success(it.conversation) }
             .onStart { emit(conversationDataState) }
     }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
@@ -270,12 +270,14 @@ internal open class ConversationViewModel(
 
         // Receive websocket updates and store them in the db.
         viewModelScope.launch(coroutineContext) {
-            serverConfigurationService.host.collect { host ->
-                webSocketUpdateUseCase.updatePosts(
-                    host = host,
-                    context = MetisContext.Conversation(courseId, conversationId)
-                )
-            }
+            combine(serverConfigurationService.host, clientId.filterSuccess()) { host, clientId -> host to clientId }
+                .collect { (host, clientId) ->
+                    webSocketUpdateUseCase.updatePosts(
+                        host = host,
+                        context = metisContext,
+                        clientId = clientId
+                    )
+                }
         }
     }
 

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationWebSocketUpdateUseCase.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationWebSocketUpdateUseCase.kt
@@ -1,11 +1,10 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 
-import android.util.Log
 import de.tum.informatics.www1.artemis.native_app.core.websocket.WebsocketProvider
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.storage.MetisStorageService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisPostAction
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisCrudAction
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisPostDTO
 
 /**
@@ -43,25 +42,24 @@ class ConversationWebSocketUpdateUseCase(
         context: MetisContext,
         host: String
     ) {
-        Log.d("WebSocket", "Received post update: ${dto.action} ${dto.post}")
         when (dto.action) {
-            MetisPostAction.CREATE -> {
+            MetisCrudAction.CREATE -> {
                 metisStorageService.insertLiveCreatedPost(host, context, dto.post)
             }
 
-            MetisPostAction.UPDATE -> {
+            MetisCrudAction.UPDATE -> {
                 metisStorageService.updatePost(host, context, dto.post)
             }
 
-            MetisPostAction.DELETE -> {
+            MetisCrudAction.DELETE -> {
                 metisStorageService.deletePosts(
                     host,
                     listOf(dto.post.id ?: return)
                 )
             }
 
-            MetisPostAction.NEW_MESSAGE -> {
-
+            MetisCrudAction.NEW_MESSAGE -> {
+                // Nothing to do here. Only relevant for the conversation overview.
             }
         }
     }

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationOverviewViewModel.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationOverviewViewModel.kt
@@ -21,7 +21,7 @@ import de.tum.informatics.www1.artemis.native_app.core.websocket.WebsocketProvid
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ConversationCollections.ConversationCollection
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.service.storage.ConversationPreferenceService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisPostAction
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisCrudAction
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.ConversationWebsocketDto
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.Conversation
@@ -281,13 +281,15 @@ class ConversationOverviewViewModel(
                         is ServerSentConversationUpdate -> {
                             val serverSentUpdate = update.update
 
+                            // TODO: It seems like there are no updates received from the websocket -> investigate
+
                             when (serverSentUpdate.crudAction) {
-                                MetisPostAction.CREATE, MetisPostAction.UPDATE -> {
+                                MetisCrudAction.CREATE, MetisCrudAction.UPDATE -> {
                                     currentConversations[serverSentUpdate.conversation.id] =
                                         serverSentUpdate.conversation
                                 }
 
-                                MetisPostAction.NEW_MESSAGE -> {
+                                MetisCrudAction.NEW_MESSAGE -> {
                                     val isMetisContextVisible =
                                         visibleMetisContexts.value.any { visibleMetisContext ->
                                             val metisContext = visibleMetisContext.metisContext
@@ -305,7 +307,7 @@ class ConversationOverviewViewModel(
                                     }
                                 }
 
-                                MetisPostAction.DELETE -> {
+                                MetisCrudAction.DELETE -> {
                                     currentConversations.remove(serverSentUpdate.conversation.id)
                                 }
                             }

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/MetisCrudAction.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/MetisCrudAction.kt
@@ -3,9 +3,9 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class MetisPostAction(val value: String) {
+enum class MetisCrudAction(val value: String) {
     CREATE("CREATE"),
     UPDATE("UPDATE"),
     DELETE("DELETE"),
-    NEW_MESSAGE("NEW_MESSAGE")
+    NEW_MESSAGE("NEW_MESSAGE")    // Only used when for the first message in a new conversation.
 }

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/MetisPostDTO.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/MetisPostDTO.kt
@@ -4,4 +4,4 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.d
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MetisPostDTO(val post: StandalonePost, val action: MetisPostAction)
+data class MetisPostDTO(val post: StandalonePost, val action: MetisCrudAction)

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/ConversationWebsocketDto.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/ConversationWebsocketDto.kt
@@ -1,6 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto
 
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisPostAction
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisCrudAction
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.Conversation
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -9,5 +9,5 @@ import kotlinx.serialization.Serializable
 data class ConversationWebsocketDto(
     val conversation: Conversation,
     @SerialName("metisCrudAction")
-    val crudAction: MetisPostAction
+    val crudAction: MetisCrudAction
 )

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/ConversationWebsocketExtensions.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/ConversationWebsocketExtensions.kt
@@ -1,11 +1,12 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.shared.service.network
 
 import de.tum.informatics.www1.artemis.native_app.core.websocket.WebsocketProvider
+import de.tum.informatics.www1.artemis.native_app.core.websocket.impl.WebsocketTopic
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.ConversationWebsocketDto
 import kotlinx.coroutines.flow.Flow
 
 fun WebsocketProvider.subscribeToConversationUpdates(userId: Long, courseId: Long): Flow<ConversationWebsocketDto> {
-    val topic = "/user/topic/metis/courses/$courseId/conversations/user/$userId"
+    val topic = WebsocketTopic.getConversationMetaUpdateTopic(courseId, userId)
 
     return subscribeMessage(topic, ConversationWebsocketDto.serializer())
 }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
Currently the user has to manually refresh the conversation to show post updates (such as reactions, mark as resolved) for non-coursewide channels. 
This problem was caused by only subscribing to the coursewide websocket.

This PR will fix #60 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Subscribe to non-coursewide websocket
- Renamed parameter "channel" to "topic" to match iOS and Web implementations
- Introduced `WebsocketTopic` file to centrally manage the websocket topics


### Steps for testing
Test for both a coursewide channel (eg tech-support) and a non-coursewide channel (eg groupchat):
- Go to the channel
- Write a message -> is shown in chat
- React to the message -> reaction is shown without the need to manually refresh
- Reply to message in thread with new answer
- Mark answer as "Resolves Post" -> Answer is shown as resolving

### Follow up
As mentioned in the ConversationOverviewViewModel.kt, I noticed that the Websocket updates for the conversations are not received properly. I will take care of this in a direct follow up PR to not overload this PR with changes.
