### PR TITLE
`Bugfix`: Fix padding for markdown text field in chat

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
@@ -3,12 +3,16 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -114,7 +118,7 @@ internal fun ConversationChatListScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .imePadding()
-                        .padding(bottom = padding.calculateBottomPadding()),
+                        .padding(bottom = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()),
                     viewModel = viewModel,
                     listContentPadding = PaddingValues(top = padding.calculateTopPadding()),
                     onClickViewPost = onClickViewPost,

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationThreadScreen.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationThreadScreen.kt
@@ -2,10 +2,13 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
@@ -61,7 +64,7 @@ internal fun ConversationThreadScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .imePadding()
-                .padding(bottom = padding.calculateBottomPadding())
+                .padding(bottom = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()),
         ) {
             CompositionLocalProvider(LocalReplyAutoCompleteHintProvider provides viewModel) {
                 MetisThreadUi(


### PR DESCRIPTION
### Problem Description
Some of the previously integrated updates caused an issue, which resulted in the text field being stuck to the bottom of the screen (see screenshot)

### Changes
The official insets library is now used to set the bottom padding.

### Screenshots
**Before**
![afd](https://github.com/user-attachments/assets/e3e509ea-a2c2-405c-968a-b9267cf06c37)

**After**
![DD](https://github.com/user-attachments/assets/a4e6d25a-7484-4942-8f88-d72ab288effa)
