### PR TITLE
Redesign settings screen and remove clutter

### DIFF
--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
@@ -35,8 +35,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -312,10 +312,11 @@ private fun UserInformationSection(
             }
         }
 
-        PreferenceEntry(
+        ButtonEntry(
             modifier = childModifier,
             text = stringResource(id = R.string.settings_account_logout),
-            isPrimaryButton = true,
+            isFocused = true,
+            textColor = MaterialTheme.colorScheme.error,
             onClick = onRequestLogout
         )
     }
@@ -437,7 +438,6 @@ fun PreferenceEntry(
     text: String,
     icon: ImageVector? = null,
     valueText: String? = null,
-    isPrimaryButton: Boolean = false,
     onClick: () -> Unit,
 ) {
     Box(
@@ -446,36 +446,32 @@ fun PreferenceEntry(
     ) {
         Row(
             modifier = modifier
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = if (isPrimaryButton) Arrangement.Center else Arrangement.spacedBy(
-                8.dp
-            )
+                .padding(horizontal = 16.dp, vertical = 10.dp)
         ) {
-            icon?.let {
-                Icon(
-                    imageVector = it,
-                    contentDescription = null
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                icon?.let {
+                    Icon(
+                        imageVector = it,
+                        contentDescription = null
+                    )
+                }
+
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.bodyLarge
                 )
             }
 
-            Text(
-                color = if (isPrimaryButton) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onBackground,
-                text = text,
-                style = if (isPrimaryButton) MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold) else MaterialTheme.typography.bodyLarge
-            )
+            Spacer(modifier = Modifier.weight(1f))
 
             valueText?.let {
-                Box(
-                    modifier = Modifier
-                        .weight(1f),
-                    contentAlignment = Alignment.CenterEnd
-                ) {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
-                    )
-                }
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
+                )
+
             }
         }
     }
@@ -494,9 +490,7 @@ fun ServerURLEntry(
     ) {
         Column(
             modifier = modifier
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.Start
+                .padding(horizontal = 16.dp, vertical = 10.dp)
         ) {
             Text(
                 text = text,
@@ -508,7 +502,6 @@ fun ServerURLEntry(
                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
                 modifier = Modifier.fillMaxWidth()
             )
-
         }
     }
 }
@@ -517,6 +510,8 @@ fun ServerURLEntry(
 fun ButtonEntry(
     modifier: Modifier = Modifier,
     text: String,
+    isFocused: Boolean = false,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
     onClick: () -> Unit,
 ) {
     Box(
@@ -526,19 +521,22 @@ fun ButtonEntry(
         Row(
             modifier = modifier
                 .padding(horizontal = 16.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = if (isFocused) Arrangement.Center else Arrangement.spacedBy(8.dp)
         ) {
             Text(
                 text = text,
-                style = MaterialTheme.typography.bodyLarge
+                color = textColor,
+                style = if (isFocused) MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold) else MaterialTheme.typography.bodyLarge
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            if (!isFocused) {
+                Spacer(modifier = Modifier.weight(1f))
 
-            Icon(
-                imageVector = Icons.Default.ChevronRight,
-                contentDescription = null
-            )
+                Icon(
+                    imageVector = Icons.Default.ChevronRight,
+                    contentDescription = null
+                )
+            }
         }
     }
 }

--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
-import androidx.compose.material3.Divider
+import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -182,14 +182,16 @@ private fun SettingsScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = padding.calculateTopPadding())
                 .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .padding(top = padding.calculateTopPadding())
                 .padding(bottom = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             if (authToken != null) {
-                LoggedInSettings(
-                    accountData = accountData,
+                UserInformationSection(
+                    modifier = Modifier.fillMaxWidth(),
+                    authData = accountData,
                     username = username,
                     onRequestLogout = {
                         scope.launch {
@@ -205,12 +207,14 @@ private fun SettingsScreen(
 
                             onLoggedOut()
                         }
-                    },
-                    onRequestOpenNotificationSettings = onRequestOpenNotificationSettings
+                    }
                 )
-
-                Divider()
             }
+
+            NotificationSection(
+                modifier = Modifier.fillMaxWidth(),
+                onOpenNotificationSettings = onRequestOpenNotificationSettings
+            )
 
             AboutSection(
                 modifier = Modifier.fillMaxWidth(),
@@ -231,8 +235,6 @@ private fun SettingsScreen(
                 onRequestSelectServerInstance = onNavigateUp
             )
 
-            Divider()
-
             BuildInformationSection(
                 modifier = Modifier.fillMaxWidth(),
                 versionCode = versionCode,
@@ -240,28 +242,6 @@ private fun SettingsScreen(
             )
         }
     }
-}
-
-@Composable
-private fun LoggedInSettings(
-    accountData: DataState<Account>?,
-    username: String?,
-    onRequestLogout: () -> Unit,
-    onRequestOpenNotificationSettings: () -> Unit
-) {
-    UserInformationSection(
-        modifier = Modifier.fillMaxWidth(),
-        authData = accountData,
-        username = username,
-        onRequestLogout = onRequestLogout
-    )
-
-    Divider()
-
-    NotificationSection(
-        modifier = Modifier.fillMaxWidth(),
-        onOpenNotificationSettings = onRequestOpenNotificationSettings
-    )
 }
 
 @Composable
@@ -355,7 +335,7 @@ private fun AboutSection(
     ) {
         if (!BuildConfig.hasInstanceRestriction) {
             Text(
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(bottom = 8.dp),
                 text = stringResource(id = R.string.settings_server_specifics_information),
                 style = MaterialTheme.typography.labelMedium
             )
@@ -427,6 +407,18 @@ private fun BuildInformationSection(
     }
 }
 
+@Composable
+private fun PreferenceEntry(modifier: Modifier, text: String, onClick: () -> Unit) {
+    Box(modifier = modifier.clickable(onClick = onClick)) {
+        Row(modifier = Modifier.padding(horizontal = 16.dp).padding(vertical = 10.dp)) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = text,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}
 
 @Composable
 private fun PreferenceSection(
@@ -434,40 +426,20 @@ private fun PreferenceSection(
     title: String,
     entries: @Composable ColumnScope.() -> Unit
 ) {
-    Column(modifier = modifier) {
-        val childModifier = Modifier.fillMaxWidth()
-
-        PreferenceSectionTitle(
-            modifier = childModifier.padding(horizontal = 16.dp),
-            text = title
-        )
-
-        entries()
-    }
-}
-
-@Composable
-private fun PreferenceSectionTitle(modifier: Modifier, text: String) {
-    Box(modifier = modifier) {
-        Text(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp),
-            text = text,
-            style = MaterialTheme.typography.titleLarge
-        )
-    }
-}
-
-@Composable
-private fun PreferenceEntry(modifier: Modifier, text: String, onClick: () -> Unit) {
-    Box(modifier = modifier.clickable(onClick = onClick)) {
-        Row(modifier = Modifier.padding(16.dp)) {
+    Card(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Column(
+            modifier = modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
             Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = text,
-                style = MaterialTheme.typography.bodyLarge
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
             )
+            entries()
         }
     }
 }

--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
@@ -2,7 +2,6 @@ package de.tum.informatics.www1.artemis.native_app.feature.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -16,8 +15,8 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AlternateEmail
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Mail
 import androidx.compose.material.icons.filled.Person
@@ -181,7 +180,7 @@ private fun SettingsScreen(
                 },
                 navigationIcon = {
                     IconButton(onClick = onNavigateUp) {
-                        Icon(imageVector = Icons.Default.ArrowBack, contentDescription = null)
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                     }
                 }
             )
@@ -440,39 +439,35 @@ fun PreferenceEntry(
     valueText: String? = null,
     onClick: () -> Unit,
 ) {
-    Box(
+    Row(
         modifier = modifier
             .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
     ) {
         Row(
-            modifier = modifier
-                .padding(horizontal = 16.dp, vertical = 10.dp)
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                icon?.let {
-                    Icon(
-                        imageVector = it,
-                        contentDescription = null
-                    )
-                }
-
-                Text(
-                    text = text,
-                    style = MaterialTheme.typography.bodyLarge
+            icon?.let {
+                Icon(
+                    imageVector = it,
+                    contentDescription = null
                 )
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
 
-            valueText?.let {
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
-                )
+        Spacer(modifier = Modifier.weight(1f))
 
-            }
+        valueText?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
+            )
+
         }
     }
 }
@@ -484,25 +479,21 @@ fun ServerURLEntry(
     valueText: String,
     onClick: () -> Unit,
 ) {
-    Box(
+    Column(
         modifier = modifier
             .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
     ) {
-        Column(
-            modifier = modifier
-                .padding(horizontal = 16.dp, vertical = 10.dp)
-        ) {
-            Text(
-                text = text,
-                style = MaterialTheme.typography.bodyLarge
-            )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge
+        )
 
-            Text(
-                text = valueText,
-                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
+        Text(
+            text = valueText,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 
@@ -514,29 +505,25 @@ fun ButtonEntry(
     textColor: Color = MaterialTheme.colorScheme.onSurface,
     onClick: () -> Unit,
 ) {
-    Box(
+    Row(
         modifier = modifier
             .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        horizontalArrangement = if (isFocused) Arrangement.Center else Arrangement.spacedBy(8.dp)
     ) {
-        Row(
-            modifier = modifier
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-            horizontalArrangement = if (isFocused) Arrangement.Center else Arrangement.spacedBy(8.dp)
-        ) {
-            Text(
-                text = text,
-                color = textColor,
-                style = if (isFocused) MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold) else MaterialTheme.typography.bodyLarge
+        Text(
+            text = text,
+            color = textColor,
+            style = if (isFocused) MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold) else MaterialTheme.typography.bodyLarge
+        )
+
+        if (!isFocused) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null
             )
-
-            if (!isFocused) {
-                Spacer(modifier = Modifier.weight(1f))
-
-                Icon(
-                    imageVector = Icons.Default.ChevronRight,
-                    contentDescription = null
-                )
-            }
         }
     }
 }

--- a/feature/settings/src/main/res/values/settings_strings.xml
+++ b/feature/settings/src/main/res/values/settings_strings.xml
@@ -2,9 +2,9 @@
 <resources>
     <string name="settings_screen_title">Settings</string>
     <string name="settings_account_information_section">Account information</string>
-    <string name="settings_account_information_full_name">Full name: %1$s</string>
-    <string name="settings_account_information_login">Login: %1$s</string>
-    <string name="settings_account_information_email">Email: %1$s</string>
+    <string name="settings_account_information_full_name">Full name:</string>
+    <string name="settings_account_information_login">Login:</string>
+    <string name="settings_account_information_email">Email:</string>
     <string name="settings_account_logout">Logout</string>
 
     <string name="settings_notification_section">Notifications</string>
@@ -12,7 +12,7 @@
 
     <string name="settings_about_section">About</string>
     <string name="settings_server_specifics_information">Imprint and privacy policy depend on the server you have currently selected.</string>
-    <string name="settings_server_url">Server URL: %1$s</string>
+    <string name="settings_server_url">Server URL:</string>
     <string name="settings_server_specifics_unavailable">Imprint and privacy policy are unavailable as you have not yet selected a server instance. Please select a server instance to view their privacy policy and imprint.</string>
     <string name="settings_server_specifics_unavailable_select_instance_button">Select instance</string>
     <string name="settings_about_privacy_policy">Privacy policy</string>
@@ -20,8 +20,8 @@
     <string name="settings_about_third_party_licences">Third party licenses</string>
 
     <string name="settings_build_section">Build information</string>
-    <string name="settings_build_version_code">Version code: %1$d</string>
-    <string name="settings_build_version_name">Version name: %1$s</string>
+    <string name="settings_build_version_code">Version code:</string>
+    <string name="settings_build_version_name">Version name:</string>
 
     <string name="notification_settings_screen_title">Notification settings</string>
 </resources>


### PR DESCRIPTION
### Problem Description

The settings screen is currently quite cluttered, and it is difficult to distinguish between buttons and static text. The problems have been described in #123


### Changes

This PR changes the Preference sections and introduces new Preference entries to make the view more appealing and easier to understand. See the screenshots below. This PR fixes #123

### Screenshots

Before:
<img src="https://github.com/user-attachments/assets/566163b4-7f6f-49c6-87be-2a8c886c2c80" width="400">

After:
<img src="https://github.com/user-attachments/assets/8020f88b-6dd6-485d-b6a4-fe01091e999b" width="400">


