### PR TITLE
`Bugfix`: Fix reappearing kick user dialog

### DIFF
--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/KickUserDialog.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/KickUserDialog.kt
@@ -32,7 +32,6 @@ internal fun KickUserFromChannelDialog(
 internal fun KickUserFromGroupDialog(
     humanReadableName: String,
     username: String,
-    groupName: String,
     onPressPositiveButton: () -> Unit,
     onDismissRequest: () -> Unit
 ) {

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/KickUserDialog.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/KickUserDialog.kt
@@ -37,13 +37,12 @@ internal fun KickUserFromGroupDialog(
     onDismissRequest: () -> Unit
 ) {
     MarkdownTextAlertDialog(
-        title = stringResource(
-            id = R.string.conversation_settings_dialog_kick_member_from_group_title,
+        title = stringResource(id = R.string.conversation_settings_dialog_kick_member_from_group_title,),
+        text = stringResource(
+            id = R.string.conversation_settings_dialog_kick_member_from_group_message,
             humanReadableName,
-            username,
-            groupName
+            username
         ),
-        text = stringResource(id = R.string.conversation_settings_dialog_kick_member_from_group_message),
         confirmButtonText = stringResource(id = R.string.conversation_settings_dialog_kick_member_positive),
         dismissButtonText = stringResource(id = R.string.conversation_settings_dialog_kick_member_negative),
         onPressPositiveButton = onPressPositiveButton,

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/PerformActionOnUserDialogs.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/PerformActionOnUserDialogs.kt
@@ -14,7 +14,6 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.d
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.GroupChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.OneToOneChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.humanReadableName
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.humanReadableTitle
 import kotlinx.coroutines.Deferred
 
 /**
@@ -99,7 +98,6 @@ private fun PerformActionOnUserDialogs(
                 is GroupChat -> KickUserFromGroupDialog (
                     humanReadableName = humanReadableName,
                     username = username,
-                    groupName = conversation.humanReadableTitle,
                     onPressPositiveButton = onKickUser,
                     onDismissRequest = onDismiss
                 )

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/PerformActionOnUserDialogs.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/PerformActionOnUserDialogs.kt
@@ -35,6 +35,7 @@ internal fun PerformActionOnUserDialogs(
     AwaitDeferredCompletion(
         job = performActionOnUserJob,
         onComplete = { isSuccessful ->
+            onDismiss()
             if (!isSuccessful) {
                 displayPerformActionOnUserFailedDialog = true
             }
@@ -95,10 +96,10 @@ private fun PerformActionOnUserDialogs(
                     onDismissRequest = onDismiss
                 )
 
-                is GroupChat -> KickUserFromChannelDialog(
+                is GroupChat -> KickUserFromGroupDialog (
                     humanReadableName = humanReadableName,
                     username = username,
-                    channelName = conversation.humanReadableTitle,
+                    groupName = conversation.humanReadableTitle,
                     onPressPositiveButton = onKickUser,
                     onDismissRequest = onDismiss
                 )


### PR DESCRIPTION
### Problem Description

As described in #168 the kick dialog keeps reappearing after confirming to kick a user from a group/channel.

### Changes

This PR fixes this behavior by adding the onDismiss function call to the completion function. This is necessary to clear the userActionData, which otherwise would not be set to null and causing the dialog to reappear after the reload.
Furthermore, this PR changes the dialog for groups to the correct one.
This PR fixes #168.


### Steps for testing

1. Pick a user with moderation rights or create a group
2. Go to the group or channel
3. Navigate to the settings (top right in the chat view)
4. Try removing a member
5. Verify that the dialog does not reappear after clicking on `Remove user`