### PR TITLE
`Bugfix`: Restrict message editing to user's own messages

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/post/PostContextBottomSheet.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/post/PostContextBottomSheet.kt
@@ -108,16 +108,18 @@ internal fun PostContextBottomSheet(
                     Divider()
                 }
 
-                postActions.requestEditPost?.let {
-                    ActionButton(
-                        modifier = actionButtonModifier,
-                        icon = Icons.Default.Edit,
-                        text = stringResource(id = R.string.post_edit),
-                        onClick = {
-                            onDismissRequest()
-                            it()
-                        }
-                    )
+                if(post.authorId == clientId) {
+                    postActions.requestEditPost?.let {
+                        ActionButton(
+                            modifier = actionButtonModifier,
+                            icon = Icons.Default.Edit,
+                            text = stringResource(id = R.string.post_edit),
+                            onClick = {
+                                onDismissRequest()
+                                it()
+                            }
+                        )
+                    }
                 }
 
                 postActions.requestDeletePost?.let {


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description

Admins, instructors etc. can change other users message content

### Changes

Edit button only visible for message owners.


### Steps for testing

1 Student
1 Instructor/Admin

A - Log in as the Student
Send a message in the chat.
Verify:
- The Edit button is visible to the Student for the message they sent.
- The Edit button is NOT visible to the Student for other peoples messages


B - Log in as the Instructor
Send a message in the chat.
Verify:
- The Edit button is visible to the Instructor for the message they sent.
- The Edit button is NOT visible to the Instructor for other peoples messages


### Screenshots

First image should be observe if instructor click to a students message.
Second one should be observe if a message owner clicks to their messages. 

<img width="295" alt="Screenshot 2024-12-05 at 18 09 21" src="https://github.com/user-attachments/assets/d24f29c0-14fb-4c2f-8abe-8c62d9eb6f29">
<img width="295" alt="Screenshot 2024-12-05 at 18 09 26" src="https://github.com/user-attachments/assets/422c78fa-3f73-49c3-a262-b8c594524a78">

