### PR TITLE
`Bugfix`: Close thread after deleting Parent Post

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationThreadScreen.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationThreadScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -38,6 +37,7 @@ internal fun ConversationThreadScreen(
     onNavigateUp: () -> Unit
 ) {
     val dataStatus by viewModel.conversationDataStatus.collectAsState()
+    viewModel.onCloseThread = onNavigateUp
 
     Scaffold(
         modifier = modifier,

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
@@ -382,7 +382,7 @@ internal open class ConversationViewModel(
             )
                 .bind { if (it) null else MetisModificationFailure.DELETE_POST }
                 .or(MetisModificationFailure.DELETE_POST)
-                .also { if (it != MetisModificationFailure.DELETE_POST && post is IStandalonePost && onCloseThread != null) onCloseThread?.invoke() }
+                .also { if (it != MetisModificationFailure.DELETE_POST && post is IStandalonePost) onCloseThread?.invoke() }
         }
     }
 

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
@@ -284,6 +284,8 @@ internal open class ConversationViewModel(
         }
     }
 
+    var onCloseThread: (() -> Unit)? = null
+
     /**
      * Handles a reaction click. If the client has already reacted, it deletes the reaction.
      * Otherwise it creates a reaction with the same emoji id.
@@ -380,6 +382,7 @@ internal open class ConversationViewModel(
             )
                 .bind { if (it) null else MetisModificationFailure.DELETE_POST }
                 .or(MetisModificationFailure.DELETE_POST)
+                .also { if (it != MetisModificationFailure.DELETE_POST && post is IStandalonePost && onCloseThread != null) onCloseThread?.invoke() }
         }
     }
 


### PR DESCRIPTION
### Problem Description

As described in #209, after deleting the parent post the user stays in the thread view facing a loading error, because the post is not available anymore.

### Changes

The onNavigateUp method is now passed down to the view model to be invoked after the parent post got successfully deleted in the thread view. This PR closes #209.

### Steps for testing

1. Go to the thread view.
2. Delete the Parent Post
3. Verify that you get taken back to the previous screen.
4. Try the same without an internet connection and verify the error dialog is still shown.
5. Try deleting an answer post in the thread view and verify that you are not taken back to the previous screen
6. Try deleting a post outside of the thread view and verify it works like before.

