### PR TITLE
`Bugfix`: Channel members search bar hardly visible

### DIFF
--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
@@ -65,7 +64,7 @@ fun ConversationMembersScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .consumeWindowInsets(WindowInsets.systemBars)
-                .padding(top = 16.dp),
+                .padding(padding),
             courseId = courseId,
             conversationId = conversationId
         )


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
In the conversation members overview, the search bar was hardly visible and hidden behind the title.

This closes #218.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Fixed padding

### Screenshots
![grafik](https://github.com/user-attachments/assets/8620b813-9089-44a9-8911-2f8f8652cc97)
