### PR TITLE
`Bugfix`: Fix conversation members overview crash due to duplicate key

### DIFF
--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersViewModel.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersViewModel.kt
@@ -50,6 +50,18 @@ internal class ConversationMembersViewModel(
 ) {
     companion object {
         private const val KEY_QUERY = "query"
+
+        private const val PAGE_SIZE = 10
+        // Given by the server, see `ConversationResource.searchMembersOfConversation()`
+        private const val MAX_REQUEST_SIZE = 20
+
+        private val PAGING_CONFIG = PagingConfig(
+            pageSize = PAGE_SIZE,
+            // From PagingConfig.kt:147: "Maximum size must be at least pageSize + 2*prefetchDist"
+            prefetchDistance = (MAX_REQUEST_SIZE - PAGE_SIZE) / 2,
+            initialLoadSize = PAGE_SIZE,
+            maxSize = MAX_REQUEST_SIZE
+        )
     }
 
     val conversation: StateFlow<DataState<Conversation>> = loadedConversation
@@ -64,7 +76,7 @@ internal class ConversationMembersViewModel(
         query.debounce(200.milliseconds)
     ) { _, conversationSettings, serverUrl, authToken, query ->
         Pager(
-            config = PagingConfig(10)
+            config = PAGING_CONFIG
         ) {
             MembersDataSource(
                 courseId = conversationSettings.courseId,

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/MembersDataSource.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/MembersDataSource.kt
@@ -15,10 +15,6 @@ internal class MembersDataSource(
     private val conversationService: ConversationService
 ) : PagingSource<Int, ConversationUser>() {
 
-    companion object {
-        private const val MAX_PAGE_SIZE = 20
-    }
-
     override fun getRefreshKey(state: PagingState<Int, ConversationUser>): Int {
         return state.anchorPosition?.let { anchorPosition ->
             (anchorPosition / state.config.pageSize) + 1
@@ -27,8 +23,7 @@ internal class MembersDataSource(
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, ConversationUser> {
         val pageNum = params.key ?: 0
-
-        val pageSize = params.loadSize.coerceAtMost(MAX_PAGE_SIZE)
+        val pageSize = params.loadSize
 
         return when (
             val membersNetworkResponse = conversationService.getMembers(


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
Sometimes when scrolling through the members overview, the app would crash.

This closes #215.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Fixed the code for creating the paging server requests
- Moved MAX_PAGE_SIZE logic to the PagingConfig

### Steps for testing
1. Go to TS1
2. Course "Artemis Feature Demo Course"
3. Go to channel #random
4. Click the settings icon
5. Scroll down the members list and click "view all members"
6. Scroll down the member list
7. See that the app no longer crashes
8. Hooray!
