### PR TITLE
`Bugfix`: Fix crash when updating post with same clientPostId

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceImpl.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceImpl.kt
@@ -148,13 +148,13 @@ internal class MetisStorageServiceImpl(
             serverId: String,
             clientSidePostId: String,
             serverSidePostId: Long?,
-            conversationId: Long = this.conversationId,
+            conversationId: Long? = null,
             postingType: BasePostingEntity.PostingType
         ): MetisPostContextEntity =
             MetisPostContextEntity(
                 serverId = serverId,
                 courseId = courseId,
-                conversationId = conversationId,
+                conversationId = conversationId ?: this.conversationId,
                 serverPostId = serverSidePostId,
                 clientPostId = clientSidePostId,
                 postingType = postingType
@@ -483,7 +483,7 @@ internal class MetisStorageServiceImpl(
                 serverId = host,
                 clientSidePostId = clientSidePostId,
                 serverSidePostId = standalonePostId,
-                conversationId = conversationId?: metisContext.conversationId,
+                conversationId = conversationId,
                 postingType = BasePostingEntity.PostingType.STANDALONE
             )
 
@@ -501,7 +501,7 @@ internal class MetisStorageServiceImpl(
                 clientSidePostId,
                 standalonePostId,
                 courseId = postMetisContext.courseId,
-                conversationId = metisContext.conversationId
+                conversationId = postMetisContext.conversationId
             )
 
             if (!isPostPresent) {

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceTestUpdatePost.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceTestUpdatePost.kt
@@ -1,0 +1,35 @@
+package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.storage.impl
+
+import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@Category(UnitTest::class)
+@RunWith(RobolectricTestRunner::class)
+class MetisStorageServiceTestUpdatePost : MetisStorageBaseTest() {
+
+    @Test
+    fun testUpdatePostWithSameClientPostId() = runTest {
+        // GIVEN: Two posts in two different conversations with the same clientPostId
+        val post1 = basePost
+        val post2 = basePostTwo
+        sut.insertOrUpdatePosts(
+            host = host,
+            metisContext = metisContext,
+            posts = listOf(post1, post2),
+        )
+
+        // WHEN: Updating post1 while the MetisContext of post2 is active
+        sut.updatePost(
+            host = host,
+            metisContext = metisContextTwo,
+            post = post1
+        )
+
+        // THEN: The previous call should not crash and this assertion should be reached
+        assert(true)
+    }
+}


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The would crash when there were two posts with the same clientPostId in different conversations (which is allowed), and one received an update for post1 while being in the metisContext of post2. This happened due to a small bug in the implementation.

This closes #241 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Fixed bug
- Added test

### Steps for testing
Follow steps described in issue and see that the crash no longer happens:

> Steps to reproduce the behavior:
> - Login as test_user_1 on TS1
> - Interactive Learning WS24/25 course
> - Go to channel #random (I think this is required to load the message in this chat)
> - Go back to Conversation Overview
> - Open DM with test_user_20
> - On the web app, as test_user_20
>   - Go to same course and #random
>   - Scroll up to post "testmessage" from Test User 16 Artemis with timestamp 2024-11-03
>   - Show replies
>   - Mark the second reply as resolving (or not resolving)
> - Android app crashes

