### PR TITLE
`Chore`: Set tum artemis server as default

### DIFF
--- a/build-logic/convention/src/main/kotlin/commonConfiguration/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/commonConfiguration/KotlinAndroid.kt
@@ -134,6 +134,8 @@ internal fun Project.configureReleaseTypeFlavors(
     }
 }
 
+private const val TUM_ARTEMIS_SERVER_URL = "https://artemis.cit.tum.de"
+
 internal fun Project.configureInstanceSelectionFlavors(
     commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
@@ -153,7 +155,7 @@ internal fun Project.configureInstanceSelectionFlavors(
                 buildConfigField(
                     "String",
                     ProductFlavors.BuildConfigFields.DefaultServerUrl,
-                    "\"\""
+                    "\"$TUM_ARTEMIS_SERVER_URL\""
                 )
             }
 
@@ -169,7 +171,7 @@ internal fun Project.configureInstanceSelectionFlavors(
                 buildConfigField(
                     "String",
                     ProductFlavors.BuildConfigFields.DefaultServerUrl,
-                    "\"https://artemis.cit.tum.de\""
+                    "\"$TUM_ARTEMIS_SERVER_URL\""
                 )
             }
         }

--- a/core/core-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/test/test_setup/TestServerConfigurationProvider.kt
+++ b/core/core-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/test/test_setup/TestServerConfigurationProvider.kt
@@ -8,7 +8,5 @@ import kotlinx.coroutines.flow.flowOf
 class TestServerConfigurationProvider : ServerConfigurationService {
     override val serverUrl: Flow<String> = flowOf(testServerUrl)
 
-    override val hasUserSelectedInstance: Flow<Boolean> = flowOf(true)
-
     override suspend fun updateServerUrl(serverUrl: String) = Unit
 }

--- a/core/datastore/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/ServerConfigurationServiceStub.kt
+++ b/core/datastore/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/ServerConfigurationServiceStub.kt
@@ -1,12 +1,10 @@
 package de.tum.informatics.www1.artemis.native_app.core.datastore
 
-import de.tum.informatics.www1.artemis.native_app.core.datastore.ServerConfigurationService
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 class ServerConfigurationServiceStub(
-    override val serverUrl: Flow<String> = flowOf("https://example.com"),
-    override val hasUserSelectedInstance: Flow<Boolean> = flowOf(true)
+    override val serverUrl: Flow<String> = flowOf("https://example.com")
 ) : ServerConfigurationService {
     override suspend fun updateServerUrl(serverUrl: String) = Unit
 }

--- a/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/ServerConfigurationService.kt
+++ b/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/ServerConfigurationService.kt
@@ -21,6 +21,7 @@ interface ServerConfigurationService {
      * If [updateServerUrl] has ever been called.
      */
     val hasUserSelectedInstance: Flow<Boolean>
+        get() = serverUrl.map { it.isNotBlank() }
 
     suspend fun updateServerUrl(serverUrl: String)
 }

--- a/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/ServerConfigurationService.kt
+++ b/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/ServerConfigurationService.kt
@@ -17,11 +17,5 @@ interface ServerConfigurationService {
     val host: Flow<String>
         get() = serverUrl.map { Url(it).host }
 
-    /**
-     * If [updateServerUrl] has ever been called.
-     */
-    val hasUserSelectedInstance: Flow<Boolean>
-        get() = serverUrl.map { it.isNotBlank() }
-
     suspend fun updateServerUrl(serverUrl: String)
 }

--- a/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/impl/ServerConfigurationServiceImpl.kt
+++ b/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/impl/ServerConfigurationServiceImpl.kt
@@ -1,13 +1,11 @@
 package de.tum.informatics.www1.artemis.native_app.core.datastore.impl
 
 import android.content.Context
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import de.tum.informatics.www1.artemis.native_app.core.datastore.BuildConfig
 import de.tum.informatics.www1.artemis.native_app.core.datastore.ServerConfigurationService
-import io.ktor.http.Url
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
@@ -28,7 +26,6 @@ internal class ServerConfigurationServiceImpl(
         private val Context.serverCommunicationPreferences by preferencesDataStore("server_communication")
 
         private val SERVER_URL_KEY = stringPreferencesKey("server_url")
-        private val HAS_SELECTED_INSTANCE_KEY = booleanPreferencesKey("has_selected_instance")
     }
 
     /**
@@ -47,28 +44,9 @@ internal class ServerConfigurationServiceImpl(
             .shareIn(GlobalScope, SharingStarted.Eagerly, replay = 1)
     }
 
-    override val host: Flow<String> =
-        serverUrl
-            .map { Url(it).host }
-
-    /**
-     * Use to decide if we want to show an instance selection UI to the user.
-     * If [BuildConfig.hasInstanceRestriction] is set to true, we never want to show such a UI.
-     */
-    override val hasUserSelectedInstance: Flow<Boolean> =
-        if (BuildConfig.hasInstanceRestriction) flowOf(true)
-        else {
-            context
-                .serverCommunicationPreferences
-                .data
-                .map { it[HAS_SELECTED_INSTANCE_KEY] ?: false }
-        }
-
-
     override suspend fun updateServerUrl(serverUrl: String) {
         context.serverCommunicationPreferences.edit { data ->
             data[SERVER_URL_KEY] = serverUrl
-            data[HAS_SELECTED_INSTANCE_KEY] = true
         }
     }
 }

--- a/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/AccountUi.kt
+++ b/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/AccountUi.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
@@ -252,7 +254,9 @@ private fun LoginUiScreen(
             )
         }
     ) { paddingValues ->
-        val sheetState = rememberModalBottomSheetState()
+        val sheetState = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true
+        )
         val scope = rememberCoroutineScope()
         var showBottomSheet by remember { mutableStateOf(false) }
 
@@ -261,7 +265,8 @@ private fun LoginUiScreen(
                 .fillMaxSize()
                 .imePadding()
                 .consumeWindowInsets(WindowInsets.systemBars)
-                .padding(top = paddingValues.calculateTopPadding()),
+                .padding(top = paddingValues.calculateTopPadding())
+                .padding(horizontal = Spacings.ScreenHorizontalSpacing),
             navController = nestedNavController,
             startDestination = NestedDestination.Home
         ) {
@@ -390,10 +395,12 @@ private fun AccountScreen(
     onClickSaml2Login: (rememberMe: Boolean) -> Unit
 ) {
     val serverProfileInfo by viewModel.serverProfileInfo.collectAsState()
+    val selectedInstance by viewModel.selectedArtemisInstance.collectAsState()
 
     AccountUi(
         modifier = modifier,
         serverProfileInfo = serverProfileInfo,
+        host = selectedInstance.host,
         canSwitchInstance = canSwitchInstance,
         retryLoadServerProfileInfo = viewModel::requestReloadServerProfileInfo,
         onNavigateToLoginScreen = onNavigateToLoginScreen,
@@ -408,6 +415,7 @@ private fun AccountScreen(
 private fun AccountUi(
     modifier: Modifier,
     serverProfileInfo: DataState<ProfileInfo>,
+    host: String,
     canSwitchInstance: Boolean,
     retryLoadServerProfileInfo: () -> Unit,
     onNavigateToLoginScreen: () -> Unit,
@@ -425,7 +433,10 @@ private fun AccountUi(
                 .fillMaxHeight(0.05f)
         )
 
-        ArtemisHeader(modifier = Modifier.fillMaxWidth())
+        ArtemisHeader(
+            modifier = Modifier.fillMaxWidth(),
+            host = host
+        )
 
         Box(
             modifier = Modifier
@@ -509,7 +520,7 @@ private fun RegisterLoginAccount(
                         //Just for the preview.
                         LoginUi(
                             modifier = loginUiModifier,
-                            accountName = "TUm",
+                            accountName = "TUM",
                             needsToAcceptTerms = true,
                             hasUserAcceptedTerms = true,
                             saml2Config = null,
@@ -596,10 +607,16 @@ private fun LoginOrRegister(
 }
 
 @Composable
-internal fun ArtemisHeader(modifier: Modifier) {
-    Column(modifier = modifier) {
+internal fun ArtemisHeader(
+    modifier: Modifier,
+    host: String
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
         Text(
-            modifier = Modifier.fillMaxWidth(),
             text = stringResource(id = R.string.account_screen_title),
             fontSize = 32.sp,
             fontWeight = FontWeight.Bold,
@@ -607,14 +624,22 @@ internal fun ArtemisHeader(modifier: Modifier) {
         )
 
         Text(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 4.dp),
             text = stringResource(id = R.string.account_screen_subtitle),
             fontSize = 20.sp,
             fontWeight = FontWeight.Normal,
             textAlign = TextAlign.Center
         )
+
+
+        if (BuildConfig.DEBUG) {
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = host,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.secondary
+            )
+        }
     }
 }
 
@@ -625,6 +650,7 @@ fun AccountUiPreviewLoadingProfileInfo() {
         modifier = Modifier.fillMaxSize(),
         canSwitchInstance = true,
         serverProfileInfo = DataState.Loading(),
+        host = "",
         retryLoadServerProfileInfo = {},
         onNavigateToLoginScreen = {},
         onNavigateToRegisterScreen = {},
@@ -641,6 +667,7 @@ fun AccountUiPreviewFailedLoadingProfileInfo() {
         modifier = Modifier.fillMaxSize(),
         canSwitchInstance = true,
         serverProfileInfo = DataState.Failure(IOException()),
+        host = "",
         retryLoadServerProfileInfo = {},
         onNavigateToLoginScreen = {},
         onNavigateToRegisterScreen = {},
@@ -661,6 +688,7 @@ fun AccountUiPreviewWithRegister() {
                 registrationEnabled = true
             )
         ),
+        host = "",
         retryLoadServerProfileInfo = {},
         onNavigateToLoginScreen = {},
         onNavigateToRegisterScreen = {},
@@ -681,6 +709,7 @@ fun AccountUiPreviewWithoutRegister() {
                 registrationEnabled = false
             )
         ),
+        host = "",
         retryLoadServerProfileInfo = {},
         onNavigateToLoginScreen = {},
         onNavigateToRegisterScreen = {},

--- a/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/AccountUi.kt
+++ b/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/AccountUi.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -350,6 +351,9 @@ private fun LoginUiScreen(
 
         if (showBottomSheet) {
             ModalBottomSheet(
+                modifier = Modifier.padding(
+                    top = WindowInsets.systemBars.asPaddingValues().calculateTopPadding(),
+                ),
                 onDismissRequest = {
                     showBottomSheet = false
                 },

--- a/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/AccountUi.kt
+++ b/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/AccountUi.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,7 +18,6 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -32,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -46,7 +45,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -457,19 +455,17 @@ private fun AccountUi(
         )
 
         if (canSwitchInstance) {
-            ClickableText(
+            TextButton(
                 modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(
-                        bottom = WindowInsets.systemBars
-                            .asPaddingValues()
-                            .calculateBottomPadding()
-                        + 8.dp
-                    ),
-                text = AnnotatedString(stringResource(id = R.string.account_change_artemis_instance_label)),
-                style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.linkTextColor),
-                onClick = { onNavigateToInstanceSelection() }
-            )
+                    .padding(vertical = 8.dp)
+                    .align(Alignment.CenterHorizontally),
+                onClick = onNavigateToInstanceSelection
+            ) {
+                Text(
+                    text = stringResource(id = R.string.account_change_artemis_instance_label),
+                    style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.linkTextColor)
+                )
+            }
         }
     }
 }

--- a/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/AccountUi.kt
+++ b/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/AccountUi.kt
@@ -88,8 +88,6 @@ private const val ARG_REMEMBER_ME = "rememberMe"
 @Serializable
 private sealed interface NestedDestination {
     @Serializable
-    data object InstanceSelection : NestedDestination
-    @Serializable
     data object CustomInstanceSelection : NestedDestination
     @Serializable
     data object Home : NestedDestination
@@ -212,12 +210,6 @@ private fun LoginUiScreen(
     val nestedNavController = rememberNavController()
     val serverConfigurationService: ServerConfigurationService = koinInject()
 
-    val hasSelectedInstance = serverConfigurationService
-        .hasUserSelectedInstance
-        .collectAsState(initial = null)
-        .value
-        ?: return // Display nothing to avoid switching between destinations
-
     // Force recomposition
     val currentBackStack by nestedNavController.currentBackStackEntryAsState()
     nestedNavController.currentBackStackEntryAsState().value
@@ -271,7 +263,7 @@ private fun LoginUiScreen(
                 .consumeWindowInsets(WindowInsets.systemBars)
                 .padding(top = paddingValues.calculateTopPadding()),
             navController = nestedNavController,
-            startDestination = if (hasSelectedInstance) NestedDestination.Home else NestedDestination.InstanceSelection
+            startDestination = NestedDestination.Home
         ) {
             animatedComposable<NestedDestination.Home> {
                 AccountScreen(
@@ -298,11 +290,7 @@ private fun LoginUiScreen(
                         .fillMaxSize()
                         .padding(horizontal = 16.dp)
                 ) {
-                    nestedNavController.navigate(NestedDestination.Home) {
-                        popUpTo<NestedDestination.InstanceSelection> {
-                            inclusive = true
-                        }
-                    }
+                    nestedNavController.navigate(NestedDestination.Home)
                 }
             }
 

--- a/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/login/LoginUi.kt
+++ b/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/login/LoginUi.kt
@@ -3,7 +3,6 @@ package de.tum.informatics.www1.artemis.native_app.feature.login.login
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
@@ -193,7 +192,7 @@ internal fun LoginUi(
         )
 
         val loginModifier = Modifier
-            .padding(16.dp)
+            .padding(vertical = 16.dp)
             .widthIn(max = 600.dp)
             .fillMaxWidth(0.8f)
             .align(Alignment.CenterHorizontally)

--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/SettingsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AlternateEmail
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Mail
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -147,10 +146,6 @@ private fun SettingsScreen(
 
     val scope = rememberCoroutineScope()
 
-    val hasUserSelectedInstance by serverConfigurationService.hasUserSelectedInstance.collectAsState(
-        initial = false
-    )
-
     val accountDataService: AccountDataService = koinInject()
     val networkStatusProvider: NetworkStatusProvider = koinInject()
 
@@ -230,7 +225,6 @@ private fun SettingsScreen(
 
             AboutSection(
                 modifier = Modifier.fillMaxWidth(),
-                hasUserSelectedInstance = hasUserSelectedInstance,
                 serverUrl = serverUrl,
                 onOpenPrivacyPolicy = {
                     val link = URLBuilder(serverUrl).appendPathSegments("privacy").buildString()
@@ -242,9 +236,6 @@ private fun SettingsScreen(
                     linkOpener.openLink(link)
                 },
                 onOpenThirdPartyLicenses = onDisplayThirdPartyLicenses,
-                // it can only be unselected, if the user has navigated to the settings from the instance selection screen.
-                // Therefore, a simple navigate up will let the user select the server instance.
-                onRequestSelectServerInstance = onNavigateUp
             )
 
             BuildInformationSection(
@@ -341,9 +332,7 @@ private fun NotificationSection(modifier: Modifier, onOpenNotificationSettings: 
 @Composable
 private fun AboutSection(
     modifier: Modifier,
-    hasUserSelectedInstance: Boolean,
     serverUrl: String,
-    onRequestSelectServerInstance: () -> Unit,
     onOpenPrivacyPolicy: () -> Unit,
     onOpenImprint: () -> Unit,
     onOpenThirdPartyLicenses: () -> Unit
@@ -362,7 +351,7 @@ private fun AboutSection(
             )
         }
 
-        if (hasUserSelectedInstance) {
+        if (serverUrl.isNotEmpty()) {
             ServerURLEntry(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(R.string.settings_server_url),
@@ -385,19 +374,12 @@ private fun AboutSection(
                 onClick = onOpenImprint
             )
         } else {
-            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                Text(
-                    text = stringResource(id = R.string.settings_server_specifics_unavailable),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
-                )
-
-                Button(
-                    onClick = onRequestSelectServerInstance
-                ) {
-                    Text(text = stringResource(id = R.string.settings_server_specifics_unavailable_select_instance_button))
-                }
-            }
+            Text(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                text = stringResource(id = R.string.settings_server_specifics_unavailable),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error
+            )
         }
 
         ButtonEntry(


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The current Artemis Android release in the Play Store uses the "Tum" build flavor, which does not allow instance (artemis server) selection. Simply switching the released build flavor to "unrestricted" would have caused already logged in users with weird behaviour (all network calls would fail because it would try to reach the artemis server via localhost; only a logout and sign in again would have resolved this issue).

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Changed the default server for the "unrestricted" flavor to the tum artemis server
- Adapted settings code to rely on the `serverUrl` instead of the duplicated logic with `hasUserSelectedInstance`
  - Removed now no longer needed code `hasUserSelectedInstance`
- Fixed bug introduced by https://github.com/ls1intum/artemis-android/pull/222, as it removed the `NestedDestination.InstanceSelection` navigation target, but did not remove it in other places of the code. This would lead to an app crash just after freshly installing the app.

### Steps for testing
#### Scenario 1 - Updating the app from "tum" to "unrestricted" flavor
- Uninstall the app on the test device
- Switch the build variant by Menu > Build > Select Build variant ... and select "productionTumDebug" for `:app`
- Launch the app and log in with your TUM credentials
- Now we check that changing to new release version with the "unrestricted" flavor works as expected:
  - Change the build variant to "productionUnrestrictedDebug" for `:app`
  - Launch the app
  - See that you are still logged in with your account to the TUM server and the dashboard is loaded

#### Scenario 2 - Fresh install
- Uninstall the app on the test device
- Directly change the build variant to "productionUnrestrictedDebug" for `:app`
- Launch the app
- See that by default the tum instance is selected for login, but the user can also select a different server by pressing "not your university"