### PR TITLE
`Bugfix`: Fix location of Conversation Dropdown Menu

### DIFF
--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationList.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationList.kt
@@ -379,17 +379,17 @@ private fun ConversationListItem(
             ) {
                 Icon(imageVector = Icons.Default.MoreHoriz, contentDescription = null)
             }
-        }
 
-        ConversationListItemDropdownMenu(
-            modifier = Modifier.align(Alignment.TopEnd),
-            isContextDialogShown = isContextDialogShown,
-            onDismissRequest = onDismissRequest,
-            conversation = conversation,
-            onToggleMarkAsFavourite = onToggleMarkAsFavourite,
-            onToggleHidden = onToggleHidden,
-            onToggleMuted = onToggleMuted
-        )
+            ConversationListItemDropdownMenu(
+                modifier = Modifier.align(Alignment.TopEnd),
+                isContextDialogShown = isContextDialogShown,
+                onDismissRequest = onDismissRequest,
+                conversation = conversation,
+                onToggleMarkAsFavourite = onToggleMarkAsFavourite,
+                onToggleHidden = onToggleHidden,
+                onToggleMuted = onToggleMuted
+            )
+        }
     }
 }
 


### PR DESCRIPTION
### Problem Description

Currently, the dropdown menu in the conversation list overview is opened on the left side of the screen, but I should open on the right side below the IconButton that triggers it.

### Changes
This PR moves the ConversationListItemDropdownMenu into the box, which is aligned at the CenterEnd.


### Steps for testing
1. Go to a ConversationList
2. Click the More-icon on any conversation
3. Verify that the Dropdown menu opens on the right side

### Screenshots
Before:
<img src="https://github.com/user-attachments/assets/3fee4646-0714-4348-83a4-25921777f396" height="160"/>

After:
<img src="https://github.com/user-attachments/assets/804a4069-ca4a-4656-a9bf-ae56c892db42" height="150"/>
