### PR TITLE
`Improvement`: Add member count to chat top bar title

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
@@ -1,6 +1,7 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -39,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
@@ -48,6 +50,7 @@ import de.tum.informatics.www1.artemis.native_app.core.data.isSuccess
 import de.tum.informatics.www1.artemis.native_app.core.ui.BuildConfig
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.BasicHintTextField
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.EmptyDataStateUi
+import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.chatlist.ChatListItem
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.chatlist.MetisChatList
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.reply.LocalReplyAutoCompleteHintProvider
@@ -55,6 +58,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.shared.isReplyEnabled
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.StandalonePostId
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.Conversation
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.OneToOneChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.ConversationIcon
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.humanReadableName
 import io.github.fornewid.placeholder.material3.placeholder
@@ -251,10 +255,26 @@ private fun ConversationTitle(
 
         Spacer(Modifier.width(8.dp))
 
-        Text(
-            text = conversation.humanReadableName,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+        Column {
+            Text(
+                text = conversation.humanReadableName,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            if (conversation !is OneToOneChat) {
+                Text(
+                    text = pluralStringResource(
+                        id = R.plurals.conversation_name_member_count,
+                        count = conversation.numberOfMembers,
+                        conversation.numberOfMembers
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
     }
 }

--- a/feature/metis/conversation/src/main/res/values/conversation_strings.xml
+++ b/feature/metis/conversation/src/main/res/values/conversation_strings.xml
@@ -8,6 +8,10 @@
     </plurals>
 
     <string name="thread_view_title">Thread</string>
+    <plurals name="conversation_name_member_count">
+        <item quantity="one">1 Member</item>
+        <item quantity="other">%1$d Members</item>
+    </plurals>
 
     <string name="course_wide_context_organization">Organization</string>
     <string name="course_wide_context_tech_support">Tech Support</string>


### PR DESCRIPTION
### Problem Description
The member count is not shown in the Top bar like it is shown on iOS.

### Changes
The Top Bar title of the chat has been changed to a column to also show the number of members if the conversation is not a DM chat.


### Steps for testing
1. Verify that the member count is represented correctly in a chat
2. Verify that it is not shown for DM chats

### Screenshots
![xxx](https://github.com/user-attachments/assets/55f13ed2-ab96-42b4-8811-6eb59e167a0c)

