### PR TITLE
`Improvement`: Increase space below notification settings categories

### DIFF
--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingCategoriesListUi.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingCategoriesListUi.kt
@@ -3,8 +3,10 @@ package de.tum.informatics.www1.artemis.native_app.feature.push.ui
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
@@ -105,6 +107,8 @@ private fun PushNotificationSettingsList(
                 }
             }
         }
+
+        Spacer(modifier = Modifier.height(32.dp))
     }
 }
 


### PR DESCRIPTION
### Problem Description

When scrolling to the end of the notification settings, the floating action button to save the changes is placed right above the switch of the last notification category making it hard for users to reach this switch.

### Changes

A spacer has been added below the list to increase the padding after the last category. This allows users to reach the switch more easily.


### Steps for testing

Scroll to the end of the notification settings and verify that there is enough space now to reach both, the last switch and the floating action button.

### Screenshots
![Screenshot5](https://github.com/user-attachments/assets/c4bfa400-a75c-420f-ac3b-6bea4ec959f6)

