### PR TITLE
`Chore`: Fix window insets usage

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/Spacings.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/Spacings.kt
@@ -12,8 +12,13 @@ import androidx.compose.ui.unit.dp
 
 object Spacings {
     val ScreenHorizontalSpacing = 16.dp
-    val ReplyTextFieldHorizontalSpacing = ScreenHorizontalSpacing / 2
     val EndOfScrollablePageSpacing = ScreenHorizontalSpacing
+
+    /**
+     * The spacing between the FAB and the end of the screen, according to the M3 guidelines:
+     * https://m3.material.io/components/floating-action-button/specs#09dc2aff-7688-4d3b-9547-bd3ab606bd8b
+     */
+    val FabPaddingValues = PaddingValues(bottom = 16.dp, end = 16.dp)
 
     object Post {
         val innerSpacing = 8.dp

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
@@ -126,7 +125,6 @@ internal fun ConversationChatListScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .imePadding()
-                        .navigationBarsPadding()
                         .padding(top = padding.calculateTopPadding())
                         .consumeWindowInsets(WindowInsets.systemBars.only(WindowInsetsSides.Top)),
                     viewModel = viewModel,

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationThreadScreen.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationThreadScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -82,8 +81,7 @@ internal fun ConversationThreadScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .imePadding()
-                .navigationBarsPadding(),
+                .imePadding(),
         ) {
             CompositionLocalProvider(LocalReplyAutoCompleteHintProvider provides viewModel) {
                 MetisThreadUi(

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisPostListHandler.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisPostListHandler.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -18,7 +17,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.LocalMarkdownTransformer
 import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.rememberPostArtemisMarkdownTransformer
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.EmojiService
@@ -85,33 +86,28 @@ internal fun <T : Any> MetisPostListHandler(
         }
     }
 
-    // use scaffold as a way to conveniently place the fab.
-    Scaffold(
-        modifier = modifier,
-        floatingActionButton = {
-            if (hasNewUnseenPost) {
-                FloatingActionButton(
-                    onClick = { scope.launch { state.scrollToItem(bottomItemIndex) } }
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.ArrowDownward,
-                        contentDescription = null
-                    )
-                }
+    Box(
+        modifier = modifier.fillMaxSize()
+    ) {
+        val markdownTransformer = rememberPostArtemisMarkdownTransformer(serverUrl, courseId)
+
+        ProvideEmojis(emojiService) {
+            CompositionLocalProvider(LocalMarkdownTransformer provides markdownTransformer) {
+                content()
             }
         }
-    ) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
-            val markdownTransformer = rememberPostArtemisMarkdownTransformer(serverUrl, courseId)
 
-            ProvideEmojis(emojiService) {
-                CompositionLocalProvider(LocalMarkdownTransformer provides markdownTransformer) {
-                    content()
-                }
+        if (hasNewUnseenPost) {
+            FloatingActionButton(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(Spacings.FabPaddingValues),
+                onClick = { scope.launch { state.scrollToItem(bottomItemIndex) } }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ArrowDownward,
+                    contentDescription = null
+                )
             }
         }
     }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextField.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextField.kt
@@ -14,18 +14,14 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -110,10 +106,9 @@ internal fun ReplyTextField(
     conversationName: String
 ) {
     val replyState: ReplyState = rememberReplyState(replyMode, updateFailureState)
-    val systemBarHeight = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
 
     Surface(
-        modifier = modifier.defaultMinSize(minHeight = (59.dp + systemBarHeight)),
+        modifier = modifier,
         border = BorderStroke(
             1.dp,
             Brush.verticalGradient(
@@ -132,8 +127,7 @@ internal fun ReplyTextField(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(4.dp)
-                .padding(bottom = systemBarHeight)
-                .height(IntrinsicSize.Max)
+                .navigationBarsPadding()
         ) {
             AnimatedContent(
                 modifier = Modifier
@@ -370,7 +364,9 @@ private fun CreateReplyUi(
                 }
             } else {
                 UnfocusedPreviewReplyTextField(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
                     hintText = hintText,
                     filePickerLauncher = filePickerLauncher,
                     onRequestShowTextField = {
@@ -774,7 +770,6 @@ private fun UnfocusedPreviewReplyTextField(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
             .clickable(onClick = onRequestShowTextField)
             .testTag(TEST_TAG_UNFOCUSED_TEXT_FIELD),
         verticalAlignment = Alignment.CenterVertically

--- a/feature/metis/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/ui/SinglePageConversationBody.kt
+++ b/feature/metis/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/ui/SinglePageConversationBody.kt
@@ -3,10 +3,7 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.ui
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -125,7 +122,7 @@ internal fun SinglePageConversationBody(
 
             is OpenedConversation -> {
                 ConversationScreen(
-                    modifier = modifier.consumeWindowInsets(WindowInsets.systemBars),
+                    modifier = modifier,
                     conversationId = config.conversationId,
                     threadPostId = config.openedThread?.postId,
                     courseId = courseId,


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
This is a followup to #320. This PR fixes the usage of WindowInsets in the context of the ReplyTextField.

### Changes
- Remove the consumption of `WindowInsets.systembars` and use the `navigationBarsPadding()` at the proper composables further down the UI tree.
- Remove scaffold in `MetisPostListHandler` as it messed with the padding values (probably because this scaffold was nested inside another scaffold)


### Steps for testing
Ensure that the paddings around the ReplyTextField are not behaving weirdly. Test with different navigation modes (gesture navigation, 3 buttonnavigation)
