### PR TITLE
`Bugfix`: Show keyboard on textfield press

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownTextField.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownTextField.kt
@@ -186,6 +186,8 @@ fun BasicMarkdownTextField(
     ) {
         BasicTextField(
             modifier = modifier
+            modifier = Modifier
+                .fillMaxWidth()
                 .focusRequester(focusRequester)
                 .onFocusChanged { focusState ->
                     if (focusState.hasFocus) {

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownTextField.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownTextField.kt
@@ -181,11 +181,9 @@ fun BasicMarkdownTextField(
     Box(
         modifier = modifier
             .heightIn(max = (localTextStyle.fontSize.value * maxVisibleLines).dp)
-            .background(MaterialTheme.colorScheme.background)
             .verticalScroll(scrollState)
     ) {
         BasicTextField(
-            modifier = modifier
             modifier = Modifier
                 .fillMaxWidth()
                 .focusRequester(focusRequester)
@@ -203,10 +201,7 @@ fun BasicMarkdownTextField(
             value = textFieldValue,
             onValueChange = onTextChanged,
             decorationBox = { innerTextField ->
-                Box(
-                    modifier = Modifier
-                        .background(MaterialTheme.colorScheme.background)
-                ) {
+                Box {
                     if (textFieldValue.text.isEmpty()) {
                         Text(
                             modifier = Modifier.align(Alignment.CenterStart),

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownTextField.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownTextField.kt
@@ -78,8 +78,7 @@ internal fun MarkdownTextField(
     hintText: AnnotatedString,
     filePickerLauncher: ManagedActivityResultLauncher<String, Uri?>,
     focusRequester: FocusRequester = remember { FocusRequester() },
-    sendButton: @Composable () -> Unit = {},
-    topRightButton: @Composable RowScope.() -> Unit = {},
+    textFieldTrailingContent: @Composable RowScope.() -> Unit = {},
     onFocusAcquired: () -> Unit = {},
     onFocusLost: () -> Unit = {},
     onTextChanged: (TextFieldValue) -> Unit,
@@ -123,9 +122,7 @@ internal fun MarkdownTextField(
                 }
             }
 
-            sendButton()
-
-            topRightButton()
+            textFieldTrailingContent()
         }
 
 

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownTextField.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownTextField.kt
@@ -68,9 +68,7 @@ import kotlinx.coroutines.launch
 const val TEST_TAG_MARKDOWN_TEXTFIELD = "TEST_TAG_MARKDOWN_TEXTFIELD"
 val textFormattingOptionsHiddenOffsetY = 200.dp
 
-/**
- * @param sendButton composable centered vertically right to the text field.
- */
+
 @Composable
 internal fun MarkdownTextField(
     modifier: Modifier,

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextField.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextField.kt
@@ -329,23 +329,18 @@ private fun CreateReplyUi(
                             onTextChanged = replyMode::onUpdate
                         )
                     },
-                    sendButton = {
+                    textFieldTrailingContent = {
                         SendButton(
                             modifier = Modifier,
                             currentTextFieldValue = currentTextFieldValue,
                             replyMode = replyMode,
                             onReply = onReply
                         )
-                    },
-                    topRightButton = {
+
                         if (replyMode is ReplyMode.EditMessage) {
-                            IconButton(onClick = replyMode.onCancelEditMessage) {
-                                Icon(
-                                    imageVector = Icons.Default.Cancel,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                                )
-                            }
+                            CancelButton(
+                                onClick = replyMode.onCancelEditMessage
+                            )
                         }
                     },
                     formattingOptionButtons = {
@@ -527,6 +522,23 @@ private fun SendButton(
                 contentDescription = null
             )
         }
+    }
+}
+
+@Composable
+private fun CancelButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    IconButton(
+        modifier = modifier,
+        onClick = onClick
+    ) {
+        Icon(
+            imageVector = Icons.Default.Cancel,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+        )
     }
 }
 


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
When pressing the right half of the ReplyTextField with a short draft message, the keyboard did not pop up. 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Fix the bug
- Refactorings

### Steps for testing
- Go to a chat with a short draft message (or create a new one)
- Click anywhere on the textfield
- -> Notice that the keyboard shows

### Screenshots
This is a recording of the problem how it previously was:


https://github.com/user-attachments/assets/645a3d06-79de-4f4e-9bf7-db570973ee9f




