### PR TITLE
`Bugfix`: Multiple bug fixes related to receiving new post updates

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisPostListHandler.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisPostListHandler.kt
@@ -49,6 +49,7 @@ internal fun <T : Any> MetisPostListHandler(
     val scope = rememberCoroutineScope()
 
     var prevBottomItem: T? by remember { mutableStateOf(null) }
+    var requestScrollToBottom by remember { mutableStateOf(false) }
 
     var hasNewUnseenPost by remember { mutableStateOf(false) }
 
@@ -76,12 +77,7 @@ internal fun <T : Any> MetisPostListHandler(
         if (doesNewPostExist) {
             if (isScrolledDown) {
                 // new bottom item exists and we were previously scrolled to the bottom. Scroll down!
-
-                // For the ChatList, the bottomPost and posts are not updated synchronously.
-                // Therefore, we need to wait shortly before the new post is present in the posts
-                // and we can actually scroll to it.
-                delay(100.milliseconds)
-                state.animateScrollToItem(bottomItemIndex)
+                requestScrollToBottom = true
             } else {
                 // new bottom item exists but we are not on bottom so instead show user button.
                 hasNewUnseenPost = true
@@ -94,6 +90,17 @@ internal fun <T : Any> MetisPostListHandler(
         }
 
         prevBottomItem = bottomItem
+    }
+
+    LaunchedEffect(requestScrollToBottom) {
+        if (requestScrollToBottom) {
+            // For the ChatList, the bottomPost and posts are not updated synchronously.
+            // Therefore, we need to wait shortly before the new post is present in the posts
+            // and we can actually scroll to it.
+            delay(100.milliseconds)
+            state.animateScrollToItem(bottomItemIndex)
+            requestScrollToBottom = false
+        }
     }
 
     Box(

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisPostListHandler.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisPostListHandler.kt
@@ -25,7 +25,9 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.rememberPostA
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.EmojiService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.ProvideEmojis
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.post.DisplayPostOrder
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Handles scrolling down to new items if the list was scrolled down before the new items came in.
@@ -68,6 +70,7 @@ internal fun <T : Any> MetisPostListHandler(
             // Check if new bottom item exists
             if (bottomItem != prevBottomItem && isScrolledDown) {
                 // new bottom item exists and we were previously scrolled to the bottom. Scroll down!
+                delay(100.milliseconds)
                 state.animateScrollToItem(bottomItemIndex)
             } else if (bottomItem != prevBottomItem) {
                 //  new bottom item exists but we are not on bottom so instead show user button.

--- a/feature/metis/shared/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ConversationServiceStub.kt
+++ b/feature/metis/shared/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ConversationServiceStub.kt
@@ -163,6 +163,13 @@ open class ConversationServiceStub(
         serverUrl: String
     ): NetworkResponse<Boolean> = NetworkResponse.Failure(StubException)
 
+    override suspend fun markConversationAsRead(
+        courseId: Long,
+        conversationId: Long,
+        authToken: String,
+        serverUrl: String
+    ): NetworkResponse<Boolean> = NetworkResponse.Failure(StubException)
+
     override suspend fun markAllConversationsAsRead(
         courseId: Long,
         serverUrl: String,

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/ConversationService.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/ConversationService.kt
@@ -170,6 +170,13 @@ interface ConversationService {
         serverUrl: String
     ): NetworkResponse<Boolean>
 
+    suspend fun markConversationAsRead(
+        courseId: Long,
+        conversationId: Long,
+        authToken: String,
+        serverUrl: String
+    ): NetworkResponse<Boolean>
+
     suspend fun markAllConversationsAsRead(
         courseId: Long,
         serverUrl: String,

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
@@ -16,6 +16,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
@@ -510,6 +511,24 @@ class ConversationServiceImpl(private val ktorProvider: KtorProvider) : Conversa
             }
                 .status
                 .isSuccess()
+        }
+    }
+
+    override suspend fun markConversationAsRead(
+        courseId: Long,
+        conversationId: Long,
+        authToken: String,
+        serverUrl: String
+    ): NetworkResponse<Boolean> {
+        return performNetworkCall {
+            ktorProvider.ktorClient.patch(serverUrl) {
+                url {
+                    appendPathSegments("api", "courses", courseId.toString(), "conversations", conversationId.toString(), "mark-as-read")
+                }
+
+                cookieAuth(authToken)
+                contentType(ContentType.Application.Json)
+            }.status.isSuccess()
         }
     }
 

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/NotificationTargetManager.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/NotificationTargetManager.kt
@@ -19,8 +19,8 @@ import kotlinx.serialization.json.Json
 
 internal object NotificationTargetManager {
 
-    private val MainActivity =
-        Class.forName("de.tum.informatics.www1.artemis.native_app.android.ui.MainActivity")
+    private val MainActivity
+        get() = Class.forName("de.tum.informatics.www1.artemis.native_app.android.ui.MainActivity")
 
     private val json = Json {
         ignoreUnknownKeys = true

--- a/feature/push/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/PushNotificationVisibleContextTest.kt
+++ b/feature/push/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/PushNotificationVisibleContextTest.kt
@@ -1,0 +1,140 @@
+package de.tum.informatics.www1.artemis.native_app.feature.push
+
+import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.visiblemetiscontextreporter.VisibleMetisContext
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.visiblemetiscontextreporter.VisiblePostList
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.visiblemetiscontextreporter.VisibleStandalonePostDetails
+import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.ArtemisNotification
+import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.CommunicationArtemisNotification
+import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.CommunicationNotificationType
+import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.ReplyPostCommunicationNotificationType
+import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.StandalonePostCommunicationNotificationType
+import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.target.CommunicationPostTarget
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.PushNotificationHandlerImpl
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@Category(UnitTest::class)
+@RunWith(RobolectricTestRunner::class)
+class PushNotificationVisibleContextTest {
+
+    private val courseId = 1L
+    private val conversationId = 2L
+    private val postId = 3L
+
+    @Test
+    fun `test GIVEN no visible context WHEN calling isNotificationContextInVisibleMetisContexts THEN return false`() {
+        val notification = buildNotification(
+            type = StandalonePostCommunicationNotificationType.CONVERSATION_NEW_MESSAGE,
+            target = buildTarget()
+        )
+        val visibleMetisContexts = emptyList<VisibleMetisContext>()
+
+        val result = PushNotificationHandlerImpl.isNotificationContextInVisibleMetisContexts(
+            notification = notification,
+            visibleMetisContexts = visibleMetisContexts
+        )
+
+        assert(!result)
+    }
+
+    @Test
+    fun `test GIVEN a visible chat context and related notification target WHEN calling isNotificationContextInVisibleMetisContexts THEN return true`() {
+        val notification = buildNotification(
+            type = StandalonePostCommunicationNotificationType.CONVERSATION_NEW_MESSAGE,
+            target = buildTarget()
+        )
+        val visibleMetisContexts = listOf(VisiblePostList(metisContext = MetisContext.Conversation(courseId, conversationId)))
+
+        val result = PushNotificationHandlerImpl.isNotificationContextInVisibleMetisContexts(
+            notification = notification,
+            visibleMetisContexts = visibleMetisContexts
+        )
+
+        assert(result)
+    }
+
+    @Test
+    fun `test GIVEN a visible chat context and unrelated notification target WHEN calling isNotificationContextInVisibleMetisContexts THEN return false`() {
+        val notification = buildNotification(
+            type = StandalonePostCommunicationNotificationType.CONVERSATION_NEW_MESSAGE,
+            target = buildTarget(conversationId = 4L)
+        )
+        val visibleMetisContexts = listOf(VisiblePostList(metisContext = MetisContext.Conversation(courseId, conversationId)))
+
+        val result = PushNotificationHandlerImpl.isNotificationContextInVisibleMetisContexts(
+            notification = notification,
+            visibleMetisContexts = visibleMetisContexts
+        )
+
+        assert(!result)
+    }
+
+    @Test
+    fun `test GIVEN a visible chat context but a thread notification target WHEN calling isNotificationContextInVisibleMetisContexts THEN return false`() {
+        val notification = buildNotification(
+            type = ReplyPostCommunicationNotificationType.CONVERSATION_NEW_REPLY_MESSAGE,
+            target = buildTarget()
+        )
+        val visibleMetisContexts = listOf(VisiblePostList(metisContext = MetisContext.Conversation(courseId, conversationId)))
+
+        val result = PushNotificationHandlerImpl.isNotificationContextInVisibleMetisContexts(
+            notification = notification,
+            visibleMetisContexts = visibleMetisContexts
+        )
+
+        assert(!result)
+    }
+
+    @Test
+    fun `test GIVEN a visible thread context and a thread notification target WHEN calling isNotificationContextInVisibleMetisContexts THEN return true`() {
+        val notification = buildNotification(
+            type = ReplyPostCommunicationNotificationType.CONVERSATION_NEW_REPLY_MESSAGE,
+            target = buildTarget()
+        )
+        val visibleMetisContexts = listOf(VisibleStandalonePostDetails(
+            metisContext = MetisContext.Conversation(courseId, conversationId),
+            postId = postId
+        ))
+
+        val result = PushNotificationHandlerImpl.isNotificationContextInVisibleMetisContexts(
+            notification = notification,
+            visibleMetisContexts = visibleMetisContexts
+        )
+
+        assert(result)
+    }
+
+
+    private fun buildNotification(
+        type: CommunicationNotificationType,
+        target: CommunicationPostTarget,
+    ): ArtemisNotification<CommunicationNotificationType> {
+        return CommunicationArtemisNotification(
+            type = type,
+            notificationPlaceholders = emptyList(),
+            target = Json.encodeToString(target),
+            date = Clock.System.now(),
+            version = 1
+        )
+    }
+
+    private fun buildTarget(
+        courseId: Long = this.courseId,
+        conversationId: Long = this.conversationId,
+        postId: Long = this.postId
+    ): CommunicationPostTarget {
+        return CommunicationPostTarget(
+            message = "",
+            entity = "",
+            postId = postId,
+            courseId = courseId,
+            conversationId = conversationId
+        )
+    }
+}


### PR DESCRIPTION
### Problem Description
This PR fixes three bugs related to receiving new posts:
1. When receiving newly created messages in a chat the conversation's unread counter was not updated as expected. After reloading the unread counter would show these newly received messages as unread again. This PR closes #226 
2. Notifications about a chat were received when in that chat.
3. In the ChatList when receiving a new post, the ChatList did not scroll to the new post automatically

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Added `markConversationAsRead` API
- Calling this API when the chat is visible
- Correct logic for checking whether notification target is visible
- Fix scrolling down when new post arrives in the ChatList


### Steps for testing
1. Activate notifications
1. Go to any chat with no unread messages
4. In the same chat, write  a message with another user from a different client (eg the web app)
5. In the android app, receive the new message 
  - ChatList automatically scrolls to new post
  - But no notification is received
5. Navigate back (and reload) and see in the ConversationOverview that the unread counter is still 0
