### PR TITLE
`Bugfix`: Add workaround for notifaction for own answer

### DIFF
--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationDao.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationDao.kt
@@ -36,7 +36,8 @@ interface PushCommunicationDao {
     @Transaction
     suspend fun insertNotification(
         artemisNotification: ArtemisNotification<CommunicationNotificationType>,
-        generateNotificationId: suspend () -> Int
+        generateNotificationId: suspend () -> Int,
+        isPostFromAppUser: suspend (CommunicationNotificationPlaceholderContent) -> Boolean
     ) {
         val parentId = artemisNotification.parentId
 
@@ -45,6 +46,12 @@ interface PushCommunicationDao {
                 type = artemisNotification.type,
                 notificationPlaceholders = artemisNotification.notificationPlaceholders
             ) ?: return
+
+            if (isPostFromAppUser(content)) {
+                // As a temporary fix for receiving notifications for own posts.
+                // See: https://github.com/ls1intum/artemis-android/issues/326
+                return
+            }
 
             if (hasPushCommunication(parentId)) {
                 updatePushCommunication(

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/push_module.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/push_module.kt
@@ -42,6 +42,9 @@ val pushModule = module {
         CommunicationNotificationManagerImpl(
             androidContext(),
             get(),
+            get(),
+            get(),
+            get(),
             get()
         )
     }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The user would get a notification when replying to its own post in a non-DM chat. 

While the root cause for this is on the server-side, I decided to add a workaround for the meantime.

This closes #326 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Check whether author of post notification is the app user and discard the notification in this case


### Steps for testing
- In the Android app enable notifications for test_user_1
- On the web app, create a post in a channel with test_user_1
- -> No notification on the android app
- On the web app, create a new answer post to the latter post (using test_user_1 again)
- -> Notice that no notification is received anymore for own answer post
