### PR TITLE
`Improvement`: Redesign Browse Channels

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/material/colors/ComponentColors.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/material/colors/ComponentColors.kt
@@ -18,4 +18,11 @@ object ComponentColors {
         val text: Color
             @Composable get() = if(isSystemInDarkTheme()) Color(0xFF36CEE6) else Color(0xFF09414A)
     }
+
+    object BrowseChannelCard {
+        val joinedBackground: Color
+            @Composable get() = Color(0xff28a745)
+        val actionText: Color
+            @Composable get() = Color.White
+    }
 }

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/browse_channels/BrowseChannelsScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/browse_channels/BrowseChannelsScreen.kt
@@ -1,6 +1,8 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.browse_channels
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -13,7 +15,7 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
-import androidx.compose.material3.ListItem
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -37,6 +39,7 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.BasicDataStateUi
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.NavigationBackButton
+import de.tum.informatics.www1.artemis.native_app.core.ui.material.colors.ComponentColors
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.ChannelChatIcon
@@ -116,7 +119,8 @@ internal fun BrowseChannelsScreen(
             if (channels.isNotEmpty()) {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = Spacings.calculateEndOfPagePaddingValues()
+                    contentPadding = Spacings.calculateEndOfPagePaddingValues(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items(channels) { channelChat ->
                         ChannelChatItem(
@@ -158,49 +162,67 @@ private fun ChannelChatItem(
     channelChat: ChannelChat,
     onClick: () -> Unit
 ) {
-    ListItem(
-        modifier = modifier,
-        leadingContent = {
-            ChannelChatIcon(channelChat = channelChat)
-        },
-        headlineContent = { Text(channelChat.name) },
-        supportingContent = {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
+    Card(
+        modifier = modifier
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                if (channelChat.isMember) {
+                Row {
+                    ChannelChatIcon(channelChat = channelChat)
+
                     Text(
-                        text = stringResource(id = R.string.joined_channel),
-                        modifier = Modifier
-                            .padding(end = 8.dp)
-                            .background(
-                                MaterialTheme.colorScheme.primary,
-                                shape = MaterialTheme.shapes.extraSmall
-                            )
-                            .padding(horizontal = 8.dp, vertical = 4.dp),
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        style = MaterialTheme.typography.labelSmall
+                        modifier = Modifier.padding(start = 8.dp),
+                        text = channelChat.name,
+                        style = MaterialTheme.typography.titleMedium
                     )
                 }
 
-                Text(
-                    text = pluralStringResource(
-                        id = R.plurals.browse_channel_channel_item_member_count,
-                        count = channelChat.numberOfMembers,
-                        channelChat.numberOfMembers
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (channelChat.isMember) {
+                        Text(
+                            text = stringResource(id = R.string.joined_channel),
+                            modifier = Modifier
+                                .padding(end = 8.dp)
+                                .background(
+                                    ComponentColors.BrowseChannelCard.joinedBackground,
+                                    shape = MaterialTheme.shapes.small
+                                )
+                                .padding(horizontal = 8.dp, vertical = 4.dp),
+                            color = ComponentColors.BrowseChannelCard.actionText,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+
+                    Text(
+                        text = pluralStringResource(
+                            id = R.plurals.browse_channel_channel_item_member_count,
+                            count = channelChat.numberOfMembers,
+                            channelChat.numberOfMembers
+                        )
                     )
-                )
+                }
             }
-        },
-        trailingContent = {
+
             if (!channelChat.isMember) {
                 Button(
-                    modifier = Modifier.testTag(testTagForBrowsedChannelItem(channelChat.id)),
+                    modifier = Modifier
+                        .testTag(testTagForBrowsedChannelItem(channelChat.id)),
                     onClick = onClick,
                 ) {
                     Text(text = stringResource(id = R.string.join_button_title))
                 }
             }
         }
-    )
+    }
 }


### PR DESCRIPTION
### Problem Description

The Browse Channels Screen does not look like the iOS app and feels cluttered.

### Changes

This is just a very small PR, that aligns the design of the Browse Channels screen with the design used in the iOS app. 
The ChannelChatItem used in the list was modified and wrapped in a Card.

### Steps for testing

Make sure it looks good.

### Screenshots

<img src="https://github.com/user-attachments/assets/48c5fe2f-7486-40fa-8f7b-b3f630a03b08" data-canonical-src="https://github.com/user-attachments/assets/48c5fe2f-7486-40fa-8f7b-b3f630a03b08" height="700" />

