### PR TITLE
`Bugfix`: Apply markdown for reverse selection

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/util/MarkdownStyleUtil.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/util/MarkdownStyleUtil.kt
@@ -21,7 +21,7 @@ internal object MarkdownStyleUtil {
             return applyAtCursorPosition(
                 style = style,
                 text = text,
-                selection = selection,
+                cursorIndex = selection.start,
                 startTag = startTag,
                 endTag = endTag
             )
@@ -39,16 +39,16 @@ internal object MarkdownStyleUtil {
     private fun applyAtCursorPosition(
         style: MarkdownStyle,
         text: String,
-        selection: TextRange,
+        cursorIndex: Int,
         startTag: String,
         endTag: String
     ): TextFieldValue {
         if (style == MarkdownStyle.CodeBlock) {
             // Insert code block with newlines
-            val newText = text.substring(0, selection.start) +
+            val newText = text.substring(0, cursorIndex) +
                     "$startTag\n\n$endTag" +
-                    text.substring(selection.end)
-            val newCursorPosition = selection.start + startTag.length + 1
+                    text.substring(cursorIndex)
+            val newCursorPosition = cursorIndex + startTag.length + 1
 
             return TextFieldValue(
                 text = newText,
@@ -58,9 +58,9 @@ internal object MarkdownStyleUtil {
             // Other styles
             val newText = text.substring(
                 0,
-                selection.start
-            ) + startTag + endTag + text.substring(selection.end)
-            val newCursorPosition = selection.start + startTag.length
+                cursorIndex
+            ) + startTag + endTag + text.substring(cursorIndex)
+            val newCursorPosition = cursorIndex + startTag.length
 
             return TextFieldValue(
                 text = newText,
@@ -76,14 +76,14 @@ internal object MarkdownStyleUtil {
         startTag: String,
         endTag: String
     ): TextFieldValue {
-        val selectedText = text.substring(selection.start, selection.end)
+        val selectedText = text.substring(selection.min, selection.max)
         if (style == MarkdownStyle.CodeBlock) {
-            val newText = text.substring(0, selection.start) +
+            val newText = text.substring(0, selection.min) +
                     "$startTag\n$selectedText\n$endTag" +
-                    text.substring(selection.end)
+                    text.substring(selection.max)
             val newSelection = TextRange(
-                selection.start + startTag.length + 1,
-                selection.end + startTag.length + 1
+                selection.min + startTag.length + 1,
+                selection.max + startTag.length + 1
             )
 
             return TextFieldValue(
@@ -91,12 +91,12 @@ internal object MarkdownStyleUtil {
                 selection = newSelection
             )
         } else {
-            val newText = text.substring(0, selection.start) +
+            val newText = text.substring(0, selection.min) +
                     startTag +
                     selectedText +
                     endTag +
-                    text.substring(selection.end)
-            val newSelection = TextRange(selection.end + startTag.length + endTag.length)
+                    text.substring(selection.max)
+            val newSelection = TextRange(selection.max + startTag.length + endTag.length)
 
             return TextFieldValue(
                 text = newText,

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/TextFieldValueExtension.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/TextFieldValueExtension.kt
@@ -1,0 +1,16 @@
+package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation
+
+import androidx.compose.ui.text.input.TextFieldValue
+import org.junit.Assert.assertEquals
+
+
+internal fun TextFieldValue.assertCursorAfterSubstring(substring: String) {
+    val firstIndex = text.indexOf(substring)
+    if (firstIndex == -1) {
+        throw IllegalArgumentException("Substring not found in the original string")
+    }
+
+    val expectedCursor = firstIndex + substring.length
+    assertEquals(expectedCursor, selection.start)
+    assertEquals(expectedCursor, selection.end)
+}

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownListContinuationUtilTest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/MarkdownListContinuationUtilTest.kt
@@ -3,6 +3,7 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
+import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.assertCursorAfterSubstring
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.reply.util.MarkdownListContinuationUtil.continueListIfApplicable
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -155,17 +156,6 @@ class MarkdownListContinuationUtilTest {
             text = newString,
             selection = TextRange(cursor, cursor)
         )
-    }
-
-    private fun TextFieldValue.assertCursorAfterSubstring(substring: String) {
-        val firstIndex = text.indexOf(substring)
-        if (firstIndex == -1) {
-            throw IllegalArgumentException("Substring not found in the original string")
-        }
-
-        val expectedCursor = firstIndex + substring.length
-        assertEquals(expectedCursor, selection.start)
-        assertEquals(expectedCursor, selection.end)
     }
 }
 

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/util/MarkdownStyleUtilTest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/util/MarkdownStyleUtilTest.kt
@@ -1,0 +1,69 @@
+package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.reply.util
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
+import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.assertCursorAfterSubstring
+import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.reply.MarkdownStyle
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+
+@Category(UnitTest::class)
+@RunWith(RobolectricTestRunner::class)
+class MarkdownStyleUtilTest {
+
+    @Test
+        fun `test GIVEN an empty selection WHEN calling apply THEN tags should be inserted at cursor position`() {
+            val text = "hello"
+            val textFieldValue = TextFieldValue(
+                text = text,
+                selection = TextRange(text.length, text.length)
+            )
+
+            val result = MarkdownStyleUtil.apply(
+                style = MarkdownStyle.Italic,
+                currentTextFieldValue = textFieldValue
+            )
+
+            assertEquals("hello**", result.text)
+            result.assertCursorAfterSubstring("hello*")
+        }
+
+        @Test
+        fun `test GIVEN a selection with start less than end WHEN calling apply THEN tags should be wrapped around selection`() {
+            val text = "hello"
+            val textFieldValue = TextFieldValue(
+                text = text,
+                selection = TextRange(0, text.length)
+            )
+
+            val result = MarkdownStyleUtil.apply(
+                style = MarkdownStyle.Italic,
+                currentTextFieldValue = textFieldValue
+            )
+
+            assertEquals("*hello*", result.text)
+            result.assertCursorAfterSubstring("*hello*")
+        }
+
+    @Test
+    fun `test GIVEN a selection with start after end WHEN calling apply THEN no error should be thrown`() {
+        val text = "hello"
+        val textFieldValue = TextFieldValue(
+            text = text,
+            selection = TextRange(text.length, 0)
+        )
+
+        val result = MarkdownStyleUtil.apply(
+            style = MarkdownStyle.Italic,
+            currentTextFieldValue = textFieldValue
+        )
+
+        assertEquals("*hello*", result.text)
+        result.assertCursorAfterSubstring("*hello*")
+    }
+}


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
When selecting some text in the ReplyTextField, and the selection was done by dragging from right to left, and the user then applied some markdown, the app crashed.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Using `selection.min/max` instead of `selection.start/end` in substring creation
- Added tests


### Steps for testing
- Go to any chat 
- Type some text into the ReplyTextField (at least two words)
- Make a reverse selection by
  - long pressing on the second word
  - while still pressing on the screen, drag to the left to the first word
  - release press
- Press any formatting option
- No crash

### Screenshots
How to reproduce the bug (here with the app crashing prior to this bugfix):

https://github.com/user-attachments/assets/e556d480-b3f1-4609-926a-f16c1459c4d0





