### PR TITLE
`Bugfix`: Fix link click conflict with post click action

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/markdown/link_resolving/MarkdownLinkResolverImpl.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/markdown/link_resolving/MarkdownLinkResolverImpl.kt
@@ -64,6 +64,11 @@ class BaseMarkdownLinkResolver(
     private val setBottomSheetState: (LinkBottomSheetState) -> Unit
 ) : LinkResolver {
     override fun resolve(view: View, link: String) {
+        // This is a workaround ensures other click functions are not triggered and prevents
+        // the thread view from being opened when clicking on a link in the chat
+        view.cancelPendingInputEvents()
+        view.isPressed = false
+
         when {
             link.endsWith(".pdf") -> {
                 setBottomSheetState(LinkBottomSheetState.PDFVIEWSTATE)

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/markdown/link_resolving/MarkdownLinkResolverImpl.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/markdown/link_resolving/MarkdownLinkResolverImpl.kt
@@ -64,7 +64,7 @@ class BaseMarkdownLinkResolver(
     private val setBottomSheetState: (LinkBottomSheetState) -> Unit
 ) : LinkResolver {
     override fun resolve(view: View, link: String) {
-        // This is a workaround ensures other click functions are not triggered and prevents
+        // This workaround ensures other click functions are not triggered and prevents
         // the thread view from being opened when clicking on a link in the chat
         view.cancelPendingInputEvents()
         view.isPressed = false


### PR DESCRIPTION
### Problem Description

Currently, when clicking on a link in the chat to open an attachment, the thread gets opened as both click events are triggered; see #271.

### Changes

This PR adds a workaround to the MarkdownLinkResolver to cancel pending click events to prevent the views onClick function from being called.
This PR fixes #271 

### Steps for testing

1. Go to a chat that contains attachment links (`random` in `Practical Course: Interactive Learning SS24` on TS3)
2. Click on the link and verify that only the pdf viewer shows up and there is no navigation to the thread.