### PR TITLE
`Feature`: Add contrast based course title text color

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/course/CourseItem.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/course/CourseItem.kt
@@ -57,6 +57,7 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.AutoResizeText
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.FontSizeRange
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.course.util.CourseUtil
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.BackgroundColorBasedTextColor
 import de.tum.informatics.www1.artemis.native_app.core.ui.deeplinks.ExerciseDeeplinks
 import de.tum.informatics.www1.artemis.native_app.core.ui.exercise.CoursePointsDecimalFormat
 import de.tum.informatics.www1.artemis.native_app.core.ui.material.colors.CourseColors
@@ -265,7 +266,7 @@ private fun CourseItemHeader(
                 .padding(vertical = 8.dp)
                 .padding(end = 16.dp),
             text = course.title,
-            color = Color.White,
+            color = BackgroundColorBasedTextColor.of(courseColor),
             textAlign = TextAlign.Center,
             fontSizeRange = FontSizeRange(min = 14.sp, max = 20.sp),
             maxLines = 2

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/BackgroundColorBasedTextColor.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/BackgroundColorBasedTextColor.kt
@@ -1,15 +1,21 @@
 package de.tum.informatics.www1.artemis.native_app.core.ui.compose
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 
 object BackgroundColorBasedTextColor {
 
     fun of(backgroundColor: Color): Color {
-        return if (backgroundColor.luminance() > 0.5f) {
+        return if (backgroundColor.brightnessW3() > 0.5f) {
             Color.Black
         } else {
             Color.White
         }
     }
+}
+
+// To be consistent with the Artemis webapp, we use the same calculation for brightness, which is
+// based on the W3 guidelines.
+// See https://github.com/ls1intum/Artemis/pull/10375/files#diff-43c9c251ad3fd69f3dcf4c7026aece29ac53a9318d0cf906ceef26544f7422f7
+fun Color.brightnessW3(): Double {
+    return 0.277 * red + 0.587 * green + 0.114 * blue
 }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
See https://github.com/ls1intum/Artemis/pull/10375

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Adjust the course title text color based on the background


### Steps for testing
- Go to a course overview
- Notice that the title colors are either black or white, based on the course card color

![image](https://github.com/user-attachments/assets/363326e9-d3dd-45bb-9778-e577e0abb9be)

