### PR TITLE
`Bugifx`: Fix Post horizontal Padding

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/post/PostWithBottomSheet.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/post/PostWithBottomSheet.kt
@@ -85,7 +85,7 @@ internal fun PostWithBottomSheet(
         }
 
     val cardModifier = applyPaddingToModifier(modifier, 4.dp)
-    val innerModifier = applyPaddingToModifier(modifier, Spacings.Post.innerSpacing)
+    val innerModifier = applyPaddingToModifier(Modifier, Spacings.Post.innerSpacing)
 
     Card(
         modifier = cardModifier,


### PR DESCRIPTION
### Problem Description

Currently, a horizontal padding of 24.dp is applied to posts in the chat.

### Changes

This PR fixes the issue described above.


### Steps for testing

Go to the chat and make sure that the post items look like they used to.
