### PR TITLE
`Improvement`: Only show relevant push notification settings

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 dependencies {
     implementation(project(":core:common"))
     api(libs.kotlinx.serialization.json)
+    testImplementation(project(":core:common-test"))
 }

--- a/core/model/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/Account.kt
+++ b/core/model/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/Account.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 open class Account(
     override val activated: Boolean = false,
-    override val authorities: List<String> = emptyList(),
+    override val authorities: List<AccountAuthority> = emptyList(),
     @SerialName("login")
     override val username: String? = null,
     override val email: String? = null,
@@ -21,19 +21,19 @@ open class Account(
     val groups: List<String> = emptyList()
 ) : BaseAccount
 
-private const val AuthorityAdmin = "ROLE_ADMIN"
-
 fun Account.isAtLeastTutorInCourse(course: Course): Boolean {
     return hasGroup(course.instructorGroupName) ||
             hasGroup(course.editorGroupName) ||
             hasGroup(course.teachingAssistantGroupName) ||
-            hasAnyAuthorityDirect(listOf(AuthorityAdmin))
+            hasAnyAuthorityDirect(listOf(AccountAuthority.ROLE_INSTRUCTOR))
 }
 
 private fun Account.hasGroup(groupName: String): Boolean {
     return groupName in groups
 }
 
-private fun Account.hasAnyAuthorityDirect(authorities: List<String>): Boolean {
+private fun Account.hasAnyAuthorityDirect(authorities: List<AccountAuthority>): Boolean {
     return this.authorities.any { it in authorities }
 }
+
+private fun Account.highestAuthority() = authorities.maxOrNull()

--- a/core/model/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/AccountAuthority.kt
+++ b/core/model/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/AccountAuthority.kt
@@ -1,0 +1,13 @@
+package de.tum.informatics.www1.artemis.native_app.core.model.account
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class AccountAuthority : Comparable<AccountAuthority> {
+    ROLE_USER,
+    /** Teaching assistant */
+    ROLE_TA,
+    ROLE_EDITOR,
+    ROLE_INSTRUCTOR,
+    ROLE_ADMIN
+}

--- a/core/model/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/BaseAccount.kt
+++ b/core/model/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/BaseAccount.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 
 interface BaseAccount {
     val activated: Boolean
-    val authorities: List<String>
+    val authorities: List<AccountAuthority>
     @SerialName("login")
     val username: String?
     val email: String?

--- a/core/model/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/User.kt
+++ b/core/model/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/User.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 class User(
     override val activated: Boolean = false,
-    override val authorities: List<String> = emptyList(),
+    override val authorities: List<AccountAuthority> = emptyList(),
     @SerialName("login")
     override val username: String? = null,
     override val email: String? = null,

--- a/core/model/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/AccountAuthorityTest.kt
+++ b/core/model/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/core/model/account/AccountAuthorityTest.kt
@@ -1,0 +1,29 @@
+package de.tum.informatics.www1.artemis.native_app.core.model.account
+
+import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+
+@Category(UnitTest::class)
+@RunWith(RobolectricTestRunner::class)
+class AccountAuthorityTest {
+
+    @Test
+    fun `test comparable`() {
+        assertTrue(AccountAuthority.ROLE_USER < AccountAuthority.ROLE_TA)
+        assertTrue(AccountAuthority.ROLE_USER < AccountAuthority.ROLE_INSTRUCTOR)
+        assertFalse(AccountAuthority.ROLE_ADMIN < AccountAuthority.ROLE_USER)
+    }
+
+    @Test
+    fun `test max`() {
+        assertEquals(AccountAuthority.ROLE_ADMIN, AccountAuthority.entries.toTypedArray().max())
+        assertEquals(AccountAuthority.ROLE_TA, listOf(AccountAuthority.ROLE_USER, AccountAuthority.ROLE_TA).max())
+    }
+}

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/CourseUser.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/CourseUser.kt
@@ -1,5 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto
 
+import de.tum.informatics.www1.artemis.native_app.core.model.account.AccountAuthority
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.ICourseUser
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -7,7 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CourseUser(
     override val activated: Boolean = false,
-    override val authorities: List<String> = emptyList(),
+    override val authorities: List<AccountAuthority> = emptyList(),
     @SerialName("login")
     override val username: String? = null,
     override val email: String? = null,

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/conversation/ConversationUser.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/conversation/ConversationUser.kt
@@ -1,5 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation
 
+import de.tum.informatics.www1.artemis.native_app.core.model.account.AccountAuthority
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.ICourseUser
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -7,7 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ConversationUser(
     override val activated: Boolean = false,
-    override val authorities: List<String> = emptyList(),
+    override val authorities: List<AccountAuthority> = emptyList(),
     @SerialName("login")
     override val username: String? = null,
     override val email: String? = null,

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/push_module.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/push_module.kt
@@ -58,5 +58,5 @@ val pushModule = module {
             get()
         )
     }
-    viewModel { PushNotificationSettingsViewModel(get(), get(), get(), get(), get()) }
+    viewModel { PushNotificationSettingsViewModel(get(), get(), get(), get(), get(), get()) }
 }

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationLocalization.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationLocalization.kt
@@ -1,0 +1,93 @@
+package de.tum.informatics.www1.artemis.native_app.feature.push.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import de.tum.informatics.www1.artemis.native_app.feature.push.R
+
+object PushNotificationLocalization {
+
+    @Composable
+    fun getGroupName(groupName: String): String {
+        val id = when (groupName) {
+            "weekly-summary" -> R.string.push_notification_settings_group_weeklySummary
+            "exercise-notification" -> R.string.push_notification_settings_group_exerciseNotifications
+            "lecture-notification" -> R.string.push_notification_settings_group_lectureNotifications
+            "tutorial-group-notification" -> R.string.push_notification_settings_group_tutorialGroupNotifications
+            "course-wide-discussion" -> R.string.push_notification_settings_group_courseWideDiscussionNotifications
+            "tutor-notification" -> R.string.push_notification_settings_group_tutorNotifications
+            "editor-notification" -> R.string.push_notification_settings_group_editorNotifications
+            "exam-notification" -> R.string.push_notification_settings_group_examNotifications
+            "instructor-notification" -> R.string.push_notification_settings_group_instructorNotifications
+            "user-notification" -> R.string.push_notification_settings_group_conversationNotification
+            else -> null
+        }
+
+        return id?.let { stringResource(id = it) } ?: groupName
+    }
+
+    @Composable
+    fun getSettingName(settingName: String): String {
+        val id = when (settingName) {
+            "basic-weekly-summary" -> R.string.push_notification_settings_setting_basicWeeklySummary
+            "exercise-released" -> R.string.push_notification_settings_setting_exerciseReleased
+            "exercise-open-for-practice" -> R.string.push_notification_settings_setting_exerciseOpenForPractice
+            "exercise-submission-assessed" -> R.string.push_notification_settings_setting_exerciseSubmissionAssessed
+            "attachment-changes" -> R.string.push_notification_settings_setting_attachmentChanges
+            "new-exercise-post" -> R.string.push_notification_settings_setting_newExercisePost
+            "new-reply-for-exercise-post" -> R.string.push_notification_settings_setting_newReplyForExercisePost
+            "new-lecture-post" -> R.string.push_notification_settings_setting_newLecturePost
+            "new-reply-for-lecture-post" -> R.string.push_notification_settings_setting_newReplyForLecturePost
+            "new-course-post" -> R.string.push_notification_settings_setting_newCoursePost
+            "new-reply-for-course-post" -> R.string.push_notification_settings_setting_newReplyForCoursePost
+            "new-announcement-post" -> R.string.push_notification_settings_setting_newAnnouncementPost
+            "course-and-exam-archiving-started" -> R.string.push_notification_settings_setting_courseAndExamArchivingStarted
+            "file-submission-successful" -> R.string.push_notification_settings_setting_fileSubmissionSuccessful
+            "programming-test-cases-changed" -> R.string.push_notification_settings_setting_programmingTestCasesChanged
+            "new-reply-for-exam-post" -> R.string.push_notification_settings_setting_newExamReply
+            "new-exam-post" -> R.string.push_notification_settings_setting_newExamPost
+            "tutorial-group-registration" -> R.string.push_notification_settings_setting_registrationTutorialGroup
+            "tutorial-group-delete-update" -> R.string.push_notification_settings_setting_tutorialGroupUpdateDelete
+            "tutorial-group-assign-unassign" -> R.string.push_notification_settings_setting_assignUnassignTutorialGroup
+            "quiz_start_reminder" -> R.string.push_notification_settings_setting_quizStartReminder
+            "conversation-message" -> R.string.push_notification_setting_setting_newConversationMessages
+            "new-reply-in-conversation" -> R.string.push_notification_setting_setting_newConversationReplies
+            "user-mention" -> R.string.push_notification_setting_setting_conversationUserMention
+            else -> null
+        }
+
+        return id?.let { stringResource(id = it) } ?: settingName
+    }
+
+    @Composable
+    fun getSettingDescription(settingName: String): String? {
+        val id = when (settingName) {
+            "basic-weekly-summary" -> R.string.push_notification_setting_setting_description_basicWeeklySummaryDescription
+            "exercise-released" -> R.string.push_notification_setting_setting_description_exerciseReleasedDescription
+            "exercise-open-for-practice" -> R.string.push_notification_setting_setting_description_exerciseOpenForPracticeDescription
+            "exercise-submission-assessed" -> R.string.push_notification_setting_setting_description_exerciseSubmissionAssessedDescription
+            "attachment-changes" -> R.string.push_notification_setting_setting_description_attachmentChangesDescription
+            "new-exercise-post" -> R.string.push_notification_setting_setting_description_newExercisePostDescription
+            "new-reply-for-exercise-post" -> R.string.push_notification_setting_setting_description_newReplyForExercisePostDescription
+            "new-lecture-post" -> R.string.push_notification_setting_setting_description_newLecturePostDescription
+            "new-reply-for-lecture-post" -> R.string.push_notification_setting_setting_description_newReplyForLecturePostDescription
+            "new-course-post" -> R.string.push_notification_setting_setting_description_newCoursePostDescription
+            "new-reply-for-course-post" -> R.string.push_notification_setting_setting_description_newReplyForCoursePostDescription
+            "new-announcement-post" -> R.string.push_notification_setting_setting_description_newAnnouncementPostDescription
+            "course-and-exam-archiving-started" -> R.string.push_notification_setting_setting_description_courseAndExamArchivingStartedDescription
+            "file-submission-successful" -> R.string.push_notification_setting_setting_description_fileSubmissionSuccessfulDescription
+            "programming-test-cases-changed" -> R.string.push_notification_setting_setting_description_programmingTestCasesChangedDescription
+            "new-reply-for-exam-post" -> R.string.push_notification_settings_setting_newExamReplyDescription
+            "new-exam-post" -> R.string.push_notification_settings_setting_newExamPostDescription
+            "tutorial-group-registration" -> R.string.push_notification_setting_setting_description_registrationTutorialGroupStudentDescription
+            "tutorial-group-delete-update" -> R.string.push_notification_setting_setting_description_tutorialGroupUpdateDeleteDescription
+            "tutorial-group-assign-unassign" -> R.string.push_notification_setting_setting_description_assignUnassignTutorialGroupDescription
+            "quiz_start_reminder" -> R.string.push_notification_setting_setting_description_quizStartReminder
+            "user-mention" -> R.string.push_notification_settings_setting_conversationUserMentionDescription
+            "new-reply-in-conversation" -> R.string.push_notification_setting_setting_newConversationRepliesDescription
+            "conversation-message" -> R.string.push_notification_setting_setting_newConversationMessagesDescription
+            else -> null
+        }
+
+        return id?.let { stringResource(id = it) }
+    }
+}

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingCategoriesListUi.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingCategoriesListUi.kt
@@ -80,7 +80,7 @@ private fun PushNotificationSettingsList(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Text(
-                        text = getLocalizedNotificationGroupName(groupName = category.categoryId),
+                        text = PushNotificationLocalization.getGroupName(groupName = category.categoryId),
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.primary
                     )
@@ -129,12 +129,12 @@ private fun PushNotificationSettingEntry(
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Text(
-                text = getLocalizedNotificationSettingName(settingName = setting.setting),
+                text = PushNotificationLocalization.getSettingName(settingName = setting.setting),
                 style = MaterialTheme.typography.bodyLarge,
             )
 
             val description =
-                getLocalizedNotificationSettingDescription(settingName = setting.setting)
+                PushNotificationLocalization.getSettingDescription(settingName = setting.setting)
             if (description != null) {
                 Text(
                     text = description,
@@ -200,90 +200,3 @@ private fun PushNotificationSettingEntry(
 //        )
 //    }
 //}
-
-@Composable
-private fun getLocalizedNotificationGroupName(groupName: String): String {
-    val id = when (groupName) {
-        "weekly-summary" -> R.string.push_notification_settings_group_weeklySummary
-        "exercise-notification" -> R.string.push_notification_settings_group_exerciseNotifications
-        "lecture-notification" -> R.string.push_notification_settings_group_lectureNotifications
-        "tutorial-group-notification" -> R.string.push_notification_settings_group_tutorialGroupNotifications
-        "course-wide-discussion" -> R.string.push_notification_settings_group_courseWideDiscussionNotifications
-        "tutor-notification" -> R.string.push_notification_settings_group_tutorNotifications
-        "editor-notification" -> R.string.push_notification_settings_group_editorNotifications
-        "exam-notification" -> R.string.push_notification_settings_group_examNotifications
-        "instructor-notification" -> R.string.push_notification_settings_group_instructorNotifications
-        "user-notification" -> R.string.push_notification_settings_group_conversationNotification
-        else -> null
-    }
-
-    return id?.let { stringResource(id = it) } ?: groupName
-}
-
-@Composable
-private fun getLocalizedNotificationSettingName(settingName: String): String {
-    val id = when (settingName) {
-        "basic-weekly-summary" -> R.string.push_notification_settings_setting_basicWeeklySummary
-        "exercise-released" -> R.string.push_notification_settings_setting_exerciseReleased
-        "exercise-open-for-practice" -> R.string.push_notification_settings_setting_exerciseOpenForPractice
-        "exercise-submission-assessed" -> R.string.push_notification_settings_setting_exerciseSubmissionAssessed
-        "attachment-changes" -> R.string.push_notification_settings_setting_attachmentChanges
-        "new-exercise-post" -> R.string.push_notification_settings_setting_newExercisePost
-        "new-reply-for-exercise-post" -> R.string.push_notification_settings_setting_newReplyForExercisePost
-        "new-lecture-post" -> R.string.push_notification_settings_setting_newLecturePost
-        "new-reply-for-lecture-post" -> R.string.push_notification_settings_setting_newReplyForLecturePost
-        "new-course-post" -> R.string.push_notification_settings_setting_newCoursePost
-        "new-reply-for-course-post" -> R.string.push_notification_settings_setting_newReplyForCoursePost
-        "new-announcement-post" -> R.string.push_notification_settings_setting_newAnnouncementPost
-        "course-and-exam-archiving-started" -> R.string.push_notification_settings_setting_courseAndExamArchivingStarted
-        "file-submission-successful" -> R.string.push_notification_settings_setting_fileSubmissionSuccessful
-        "programming-test-cases-changed" -> R.string.push_notification_settings_setting_programmingTestCasesChanged
-        "new-reply-for-exam-post" -> R.string.push_notification_settings_setting_newExamReply
-        "new-exam-post" -> R.string.push_notification_settings_setting_newExamPost
-        "tutorial-group-registration" -> R.string.push_notification_settings_setting_registrationTutorialGroup
-        "tutorial-group-delete-update" -> R.string.push_notification_settings_setting_tutorialGroupUpdateDelete
-        "tutorial-group-assign-unassign" -> R.string.push_notification_settings_setting_assignUnassignTutorialGroup
-        "quiz_start_reminder" -> R.string.push_notification_settings_setting_quizStartReminder
-        "conversation-message" -> R.string.push_notification_setting_setting_newConversationMessages
-        "new-reply-in-conversation" -> R.string.push_notification_setting_setting_newConversationReplies
-        "user-mention" -> R.string.push_notification_setting_setting_conversationUserMention
-        "data-export-failed" -> R.string.push_notification_setting_setting_conversationDataExportFailed
-        "data-export-created" -> R.string.push_notification_setting_setting_conversationDataExportCreated
-        else -> null
-    }
-
-    return id?.let { stringResource(id = it) } ?: settingName
-}
-
-@Composable
-private fun getLocalizedNotificationSettingDescription(settingName: String): String? {
-    val id = when (settingName) {
-        "basic-weekly-summary" -> R.string.push_notification_setting_setting_description_basicWeeklySummaryDescription
-        "exercise-released" -> R.string.push_notification_setting_setting_description_exerciseReleasedDescription
-        "exercise-open-for-practice" -> R.string.push_notification_setting_setting_description_exerciseOpenForPracticeDescription
-        "exercise-submission-assessed" -> R.string.push_notification_setting_setting_description_exerciseSubmissionAssessedDescription
-        "attachment-changes" -> R.string.push_notification_setting_setting_description_attachmentChangesDescription
-        "new-exercise-post" -> R.string.push_notification_setting_setting_description_newExercisePostDescription
-        "new-reply-for-exercise-post" -> R.string.push_notification_setting_setting_description_newReplyForExercisePostDescription
-        "new-lecture-post" -> R.string.push_notification_setting_setting_description_newLecturePostDescription
-        "new-reply-for-lecture-post" -> R.string.push_notification_setting_setting_description_newReplyForLecturePostDescription
-        "new-course-post" -> R.string.push_notification_setting_setting_description_newCoursePostDescription
-        "new-reply-for-course-post" -> R.string.push_notification_setting_setting_description_newReplyForCoursePostDescription
-        "new-announcement-post" -> R.string.push_notification_setting_setting_description_newAnnouncementPostDescription
-        "course-and-exam-archiving-started" -> R.string.push_notification_setting_setting_description_courseAndExamArchivingStartedDescription
-        "file-submission-successful" -> R.string.push_notification_setting_setting_description_fileSubmissionSuccessfulDescription
-        "programming-test-cases-changed" -> R.string.push_notification_setting_setting_description_programmingTestCasesChangedDescription
-        "new-reply-for-exam-post" -> R.string.push_notification_settings_setting_newExamReplyDescription
-        "new-exam-post" -> R.string.push_notification_settings_setting_newExamPostDescription
-        "tutorial-group-registration" -> R.string.push_notification_setting_setting_description_registrationTutorialGroupStudentDescription
-        "tutorial-group-delete-update" -> R.string.push_notification_setting_setting_description_tutorialGroupUpdateDeleteDescription
-        "tutorial-group-assign-unassign" -> R.string.push_notification_setting_setting_description_assignUnassignTutorialGroupDescription
-        "quiz_start_reminder" -> R.string.push_notification_setting_setting_description_quizStartReminder
-        "user-mention" -> R.string.push_notification_settings_setting_conversationUserMentionDescription
-        "new-reply-in-conversation" -> R.string.push_notification_setting_setting_newConversationRepliesDescription
-        "conversation-message" -> R.string.push_notification_setting_setting_newConversationMessagesDescription
-        else -> null
-    }
-
-    return id?.let { stringResource(id = it) }
-}

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingCategoriesListUi.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingCategoriesListUi.kt
@@ -37,13 +37,13 @@ internal fun testTagForSetting(settingId: String) = "notification setting $setti
 @Composable
 internal fun PushNotificationSettingCategoriesListUi(
     modifier: Modifier,
-    settingsByGroupDataStore: DataState<List<PushNotificationSettingsViewModel.NotificationCategory>>,
+    settingsByGroupDataState: DataState<List<PushNotificationSettingsViewModel.NotificationCategory>>,
     onUpdate: (PushNotificationSetting, webapp: Boolean?, email: Boolean?, push: Boolean?) -> Unit,
     onRequestReload: () -> Unit
 ) {
     BasicDataStateUi(
         modifier = modifier,
-        dataState = settingsByGroupDataStore,
+        dataState = settingsByGroupDataState,
         loadingText = stringResource(id = R.string.push_notification_settings_loading),
         failureText = stringResource(id = R.string.push_notification_settings_failure),
         retryButtonText = stringResource(id = R.string.push_notification_settings_try_again),

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingsUi.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingsUi.kt
@@ -74,7 +74,7 @@ fun PushNotificationSettingsUi(
         AnimatedVisibility(visible = arePushNotificationEnabled) {
             PushNotificationSettingCategoriesListUi(
                 modifier = Modifier.fillMaxWidth(),
-                settingsByGroupDataStore = settingsByGroupDataStore,
+                settingsByGroupDataState = settingsByGroupDataStore,
                 onUpdate = { setting, webapp, email, push ->
                     viewModel.updateSettingsEntry(
                         setting.settingId,

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingsViewModel.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingsViewModel.kt
@@ -12,8 +12,8 @@ import de.tum.informatics.www1.artemis.native_app.core.datastore.AccountService
 import de.tum.informatics.www1.artemis.native_app.core.datastore.ServerConfigurationService
 import de.tum.informatics.www1.artemis.native_app.core.datastore.authToken
 import de.tum.informatics.www1.artemis.native_app.core.device.NetworkStatusProvider
-import de.tum.informatics.www1.artemis.native_app.feature.push.service.network.NotificationSettingsService
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.PushNotificationConfigurationService
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.network.NotificationSettingsService
 import de.tum.informatics.www1.artemis.native_app.feature.push.ui.model.PushNotificationSetting
 import de.tum.informatics.www1.artemis.native_app.feature.push.ui.model.group
 import kotlinx.coroutines.Deferred
@@ -102,11 +102,26 @@ class PushNotificationSettingsViewModel internal constructor(
         }
             .stateIn(viewModelScope + coroutineContext, SharingStarted.Eagerly, DataState.Loading())
 
+    /**
+     * These settings can not be edited by the user
+     */
+    private val nonEditableSettingIds = listOf(
+        "notification.user-notification.vcs-access-token-added",
+        "notification.user-notification.vcs-access-token-expired",
+        "notification.user-notification.vcs-access-token-expires-soon",
+        "notification.user-notification.ssh-key-added",
+        "notification.user-notification.ssh-key-expires-soon",
+        "notification.user-notification.ssh-key-has-expired",
+        "notification.user-notification.data-export-created",
+        "notification.user-notification.data-export-failed"
+    )
+
     internal val currentSettingsByGroup: StateFlow<DataState<List<NotificationCategory>>> =
         currentSettings
             .map { currentSettings ->
                 currentSettings.bind { settings ->
                     settings
+                        .filterNot { nonEditableSettingIds.contains(it.settingId) }
                         .groupBy { it.group }
                         .map { NotificationCategory(it.key, it.value) }
                         .sortedBy { it.categoryId }

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/model/PushNotificationSettingUtil.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/model/PushNotificationSettingUtil.kt
@@ -1,0 +1,43 @@
+package de.tum.informatics.www1.artemis.native_app.feature.push.ui.model
+
+import de.tum.informatics.www1.artemis.native_app.core.model.account.AccountAuthority
+import de.tum.informatics.www1.artemis.native_app.feature.push.ui.PushNotificationSettingsViewModel
+
+object PushNotificationSettingUtil {
+
+    /**
+     * These settings can not be edited by the user
+     */
+    private val nonEditableSettingIds = listOf(
+        "notification.user-notification.vcs-access-token-added",
+        "notification.user-notification.vcs-access-token-expired",
+        "notification.user-notification.vcs-access-token-expires-soon",
+        "notification.user-notification.ssh-key-added",
+        "notification.user-notification.ssh-key-expires-soon",
+        "notification.user-notification.ssh-key-has-expired",
+        "notification.user-notification.data-export-created",
+        "notification.user-notification.data-export-failed"
+    )
+
+    private val restrictedCategoryIdByAuthority: Map<AccountAuthority, String> = mapOf(
+        AccountAuthority.ROLE_TA to "tutor-notification",
+        AccountAuthority.ROLE_EDITOR to "editor-notification",
+        AccountAuthority.ROLE_INSTRUCTOR to "instructor-notification",
+    )
+
+    internal fun List<PushNotificationSetting>.filterEditable() =
+        filterNot { nonEditableSettingIds.contains(it.settingId) }
+
+    internal fun List<PushNotificationSettingsViewModel.NotificationCategory>.filterByAuthorities(
+        authorities: List<AccountAuthority>
+    ) = filter {
+        val availableCategoryIds = authorities.map { authority ->
+            restrictedCategoryIdByAuthority[authority]
+        }.toSet()
+
+        val forbiddenCategoryIds = restrictedCategoryIdByAuthority.values - availableCategoryIds
+
+        it.categoryId !in forbiddenCategoryIds
+    }
+
+}

--- a/feature/push/src/main/res/values/push_notification_settings_strings.xml
+++ b/feature/push/src/main/res/values/push_notification_settings_strings.xml
@@ -50,8 +50,6 @@
     <string name="push_notification_setting_setting_newConversationMessages">New messages in conversations</string>
     <string name="push_notification_setting_setting_newConversationReplies">New replies in conversations</string>
     <string name="push_notification_setting_setting_conversationUserMention">New user mention in conversations</string>
-    <string name="push_notification_setting_setting_conversationDataExportFailed">Data Export has failed</string>
-    <string name="push_notification_setting_setting_conversationDataExportCreated">Data Export has been created</string>
 
     <string name="push_notification_setting_setting_description_basicWeeklySummaryDescription">Receive a basic weekly summary every Friday at 5pm (e.g. what new exercises have been released this week and are still open)"</string>
     <string name="push_notification_setting_setting_description_exerciseReleasedDescription">Get notified when a new exercise has been released"</string>

--- a/feature/push/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/PushNotificationSettingsE2eTest.kt
+++ b/feature/push/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/PushNotificationSettingsE2eTest.kt
@@ -198,6 +198,7 @@ class PushNotificationSettingsE2eTest : BaseComposeTest() {
             networkStatusProvider = get(),
             serverConfigurationService = get(),
             accountService = get(),
+            accountDataService = get(),
             pushNotificationConfigurationService = get(),
             coroutineContext = testDispatcher
         )

--- a/feature/push/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/model/PushNotificationSettingUtilTest.kt
+++ b/feature/push/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/model/PushNotificationSettingUtilTest.kt
@@ -1,0 +1,40 @@
+package de.tum.informatics.www1.artemis.native_app.feature.push.ui.model
+
+import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
+import de.tum.informatics.www1.artemis.native_app.core.model.account.AccountAuthority
+import de.tum.informatics.www1.artemis.native_app.feature.push.ui.PushNotificationSettingsViewModel
+import de.tum.informatics.www1.artemis.native_app.feature.push.ui.model.PushNotificationSettingUtil.filterByAuthorities
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@Category(UnitTest::class)
+@RunWith(RobolectricTestRunner::class)
+class PushNotificationSettingUtilTest {
+
+    @Test
+    fun `test filterByAuthorities`() {
+        val settings = listOf(
+            PushNotificationSettingsViewModel.NotificationCategory("tutor-notification", emptyList()),
+            PushNotificationSettingsViewModel.NotificationCategory("editor-notification", emptyList()),
+            PushNotificationSettingsViewModel.NotificationCategory("instructor-notification", emptyList()),
+            PushNotificationSettingsViewModel.NotificationCategory("general-notification", emptyList())
+
+        )
+
+        val authorities = listOf(AccountAuthority.ROLE_TA, AccountAuthority.ROLE_EDITOR)
+
+        val filteredSettings = settings.filterByAuthorities(authorities)
+
+        val expectedSettings = listOf(
+            PushNotificationSettingsViewModel.NotificationCategory("tutor-notification", emptyList()),
+            PushNotificationSettingsViewModel.NotificationCategory("editor-notification", emptyList()),
+            PushNotificationSettingsViewModel.NotificationCategory("general-notification", emptyList())
+        )
+
+        assertEquals(expectedSettings, filteredSettings)
+    }
+
+}


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
In Android, we displayed all notification settings as toggles in the notifications settings page, even if some of them should not support push notifications, or are not available to the user because of their role (eg students could change settings  for "Instructor Notifications")

This PR closes #439 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Hide notifications that are not relevant for push notifications (ssh, vcs-token, data-export)
- Hide notifications based on the user's authorities
- Extracted localization into `PushNotificationLocalization`
- Extracted filtering logic into new `PushNotificationSettingUtil`
- Added tests


### Steps for testing
1. Log in as a student and see that only relevant notification settings are shown
2. Log in as a tutor/editor/instructor and see that the authority based notifications are shown
