### PR TITLE
`Bugfix`: Autocompletion type does not reset

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/OnTrueLaunchedEffect.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/OnTrueLaunchedEffect.kt
@@ -1,0 +1,17 @@
+package de.tum.informatics.www1.artemis.native_app.core.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+
+
+@Composable
+fun OnTrueLaunchedEffect(
+    key: Boolean,
+    onKeyIsTrueBlock: suspend () -> Unit
+) {
+    LaunchedEffect(key) {
+        if (key) {
+            onKeyIsTrueBlock()
+        }
+    }
+}

--- a/feature/dashboard/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/dashboard/ui/CoursesOverview.kt
+++ b/feature/dashboard/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/dashboard/ui/CoursesOverview.kt
@@ -48,6 +48,7 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.BasicDataStateUi
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.BasicSearchTextField
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.NoSearchResults
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.OnTrueLaunchedEffect
 import de.tum.informatics.www1.artemis.native_app.core.ui.navigation.animatedComposable
 import de.tum.informatics.www1.artemis.native_app.feature.dashboard.BuildConfig
 import de.tum.informatics.www1.artemis.native_app.feature.dashboard.R
@@ -114,8 +115,8 @@ internal fun CoursesOverview(
     var lastOffset by remember { mutableIntStateOf(0) }
 
     // Trigger the dialog if service sets value to true
-    LaunchedEffect(shouldDisplayBetaDialog) {
-        if (shouldDisplayBetaDialog) displayBetaDialog = true
+    OnTrueLaunchedEffect(shouldDisplayBetaDialog) {
+        displayBetaDialog = true
     }
 
     LaunchedEffect(sorting, query) {

--- a/feature/dashboard/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/dashboard/ui/SurveyHint.kt
+++ b/feature/dashboard/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/dashboard/ui/SurveyHint.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,6 +33,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.OnTrueLaunchedEffect
 import de.tum.informatics.www1.artemis.native_app.feature.dashboard.R
 import de.tum.informatics.www1.artemis.native_app.feature.dashboard.service.SurveyHintService
 import kotlinx.coroutines.delay
@@ -50,8 +50,8 @@ fun SurveyHint(
     var displaySurveyHint by rememberSaveable { mutableStateOf(false) }
     var showSurveyDialog by rememberSaveable { mutableStateOf(false) }
 
-    LaunchedEffect(shouldDisplaySurveyHint) {
-        if (shouldDisplaySurveyHint) displaySurveyHint = true
+    OnTrueLaunchedEffect(shouldDisplaySurveyHint) {
+        displaySurveyHint = true
     }
 
     AnimatedVisibility(displaySurveyHint) {

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisPostListHandler.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisPostListHandler.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.OnTrueLaunchedEffect
 import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.LocalMarkdownTransformer
 import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.rememberPostArtemisMarkdownTransformer
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.EmojiService
@@ -138,14 +139,12 @@ private fun <T: Any>manageScrollToNewPost(
         prevBottomItem = bottomItem
     }
 
-    LaunchedEffect(requestScrollToBottom) {
-        if (requestScrollToBottom) {
-            // For the ChatList, the bottomPost and posts are not updated synchronously.
-            // Therefore, we need to wait shortly before the new post is present in the posts
-            // and we can actually scroll to it.
-            delay(100.milliseconds)
-            state.animateScrollToItem(bottomItemIndex)
-            requestScrollToBottom = false
-        }
+    OnTrueLaunchedEffect(requestScrollToBottom) {
+        // For the ChatList, the bottomPost and posts are not updated synchronously.
+        // Therefore, we need to wait shortly before the new post is present in the posts
+        // and we can actually scroll to it.
+        delay(100.milliseconds)
+        state.animateScrollToItem(bottomItemIndex)
+        requestScrollToBottom = false
     }
 }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextField.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextField.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat.getString
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.OnTrueLaunchedEffect
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.MetisModificationFailure
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.model.FileValidationConstants
@@ -187,19 +188,15 @@ private fun AutoCompletionDialog(
         requestDismissAutoCompletePopup = false
     }
 
-    LaunchedEffect(requestDismissAutoCompletePopup) {
-        if (requestDismissAutoCompletePopup) {
-            delay(100)
-            mayShowAutoCompletePopup = false
-            resetRequestedAutoCompleteType()
-        }
+    OnTrueLaunchedEffect(requestDismissAutoCompletePopup) {
+        delay(100)
+        mayShowAutoCompletePopup = false
+        resetRequestedAutoCompleteType()
     }
 
     val areHintsEmpty = autoCompleteHints.orEmpty().flatMap { it.items }.isEmpty()
-    LaunchedEffect(areHintsEmpty) {
-        if (areHintsEmpty) {
-            resetRequestedAutoCompleteType()
-        }
+    OnTrueLaunchedEffect(areHintsEmpty) {
+        resetRequestedAutoCompleteType()
     }
 
     val showAutoCompletePopup = mayShowAutoCompletePopup && !areHintsEmpty
@@ -300,11 +297,9 @@ private fun CreateReplyUi(
         prevReplyContent = currentTextFieldValue.text
     }
 
-    LaunchedEffect(requestFocus) {
-        if (requestFocus) {
-            focusRequester.requestFocus()
-            requestFocus = false
-        }
+    OnTrueLaunchedEffect(requestFocus) {
+        focusRequester.requestFocus()
+        requestFocus = false
     }
 
     Box(modifier.fillMaxWidth()) {

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextField.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextField.kt
@@ -194,9 +194,14 @@ private fun AutoCompletionDialog(
         }
     }
 
-    val showAutoCompletePopup = mayShowAutoCompletePopup
-            && autoCompleteHints.orEmpty().flatMap { it.items }.isNotEmpty()
+    val areHintsEmpty = autoCompleteHints.orEmpty().flatMap { it.items }.isEmpty()
+    LaunchedEffect(areHintsEmpty) {
+        if (areHintsEmpty) {
+            requestedAutoCompleteType.value = null
+        }
+    }
 
+    val showAutoCompletePopup = mayShowAutoCompletePopup && !areHintsEmpty
     if (!showAutoCompletePopup) {
         return
     }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
There was a bug where the requested AutoCompletionType did not reset after removing the tagging character.

This PR fixes #451 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- When there are not AutoCompletionHints shown, also reset the requested type
- Refactoring
- Introduce `OnTrueLaunchedEffect`

### Steps for testing
1. Go to any chat
2. Click on the mention button in the ReplyTextField
3. Click on "Lectures" in the popup
4. See that only lectures are shown
5. Remove the inserted "#" character via backspace
6. Type "#" again
7. See that all AutoCompletionTypes are shown
