### PR TITLE
`Bugfix`: Fix members scrolling bug

### DIFF
--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersBody.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersBody.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
@@ -157,6 +158,7 @@ private fun ConversationMembersList(
         is LoadState.NotLoading -> {
             LazyColumn(
                 modifier = modifier
+                    .navigationBarsPadding()
                     .nestedScroll(collapsingContentState.nestedScrollConnection)
                     .testTag(TEST_TAG_MEMBERS_LIST)
             ) {

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersBody.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersBody.kt
@@ -3,9 +3,11 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversat
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
@@ -158,9 +160,9 @@ private fun ConversationMembersList(
         is LoadState.NotLoading -> {
             LazyColumn(
                 modifier = modifier
-                    .navigationBarsPadding()
                     .nestedScroll(collapsingContentState.nestedScrollConnection)
-                    .testTag(TEST_TAG_MEMBERS_LIST)
+                    .testTag(TEST_TAG_MEMBERS_LIST),
+                contentPadding = WindowInsets.navigationBars.asPaddingValues()
             ) {
                 items(
                     count = members.itemCount,

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersBody.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersBody.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -162,8 +163,15 @@ private fun ConversationMembersList(
                 modifier = modifier
                     .nestedScroll(collapsingContentState.nestedScrollConnection)
                     .testTag(TEST_TAG_MEMBERS_LIST),
-                contentPadding = WindowInsets.navigationBars.asPaddingValues()
+                contentPadding = WindowInsets.navigationBars.asPaddingValues(),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                if (members.loadState.prepend is LoadState.Loading) {
+                    item {
+                        CircularProgressIndicator()
+                    }
+                }
+
                 items(
                     count = members.itemCount,
                     key = members.itemKey(key = { it.id })
@@ -185,9 +193,7 @@ private fun ConversationMembersList(
                 when (members.loadState.append) {
                     LoadState.Loading -> {
                         item {
-                            LinearProgressIndicator(
-                                modifier = Modifier.fillMaxWidth(),
-                            )
+                            CircularProgressIndicator()
                         }
                     }
 

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersViewModel.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/ConversationMembersViewModel.kt
@@ -51,7 +51,7 @@ internal class ConversationMembersViewModel(
     companion object {
         private const val KEY_QUERY = "query"
 
-        private const val PAGE_SIZE = 10
+        private const val PAGE_SIZE = 15
         // Given by the server, see `ConversationResource.searchMembersOfConversation()`
         private const val MAX_REQUEST_SIZE = 20
 

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/MembersDataSource.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/MembersDataSource.kt
@@ -39,7 +39,7 @@ internal class MembersDataSource(
             is NetworkResponse.Response -> {
                 LoadResult.Page(
                     membersNetworkResponse.data,
-                    null,
+                    if (pageNum > 0) pageNum - 1 else null,
                     if (membersNetworkResponse.data.size >= pageSize) pageNum + 1 else null
                 )
             }

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/MembersDataSource.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/members/MembersDataSource.kt
@@ -38,9 +38,9 @@ internal class MembersDataSource(
         ) {
             is NetworkResponse.Response -> {
                 LoadResult.Page(
-                    membersNetworkResponse.data,
-                    if (pageNum > 0) pageNum - 1 else null,
-                    if (membersNetworkResponse.data.size >= pageSize) pageNum + 1 else null
+                    data = membersNetworkResponse.data,
+                    prevKey = if (pageNum > 0) pageNum - 1 else null,
+                    nextKey = if (membersNetworkResponse.data.size >= pageSize) pageNum + 1 else null
                 )
             }
 


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
There was a bug when scrolling through a conversations members list. After scrolling down a bit, the user could not scroll back to the top again.

This PR closes #445 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Added `prevKey` to Paging result
- For some reason I had to also change the default Page size, because with `PAGE_SIZE = 10` this seemed to introduce a new bug when the user was scrolling really fast.

### Steps for testing
1. Go to any chat
2. Go to the chat's settings
3. Click on "Show all members"
4. Scroll up and down the members list
5. No weird behaviour

### Screenshots

https://github.com/user-attachments/assets/9e77eda5-95c4-4ab0-b5cd-cdc0f3b37a27

