### PR TITLE
`Bugfix`: Fix serialization error for saved posts

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/saved_posts/SavedPostItem.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/saved_posts/SavedPostItem.kt
@@ -140,7 +140,7 @@ private fun ConversationContextInfoHeader(
     isThreadReply: Boolean,
 ) {
     val contextText = when (conversation.type) {
-        ISavedPost.SimpleConversationInfo.ConversationType.CHANNEL -> conversation.title
+        ISavedPost.SimpleConversationInfo.ConversationType.CHANNEL -> conversation.title ?: stringResource(id = R.string.saved_posts_context_channel)
         ISavedPost.SimpleConversationInfo.ConversationType.DIRECT -> stringResource(id = R.string.saved_posts_context_private_chat)
     }
 

--- a/feature/metis/conversation/src/main/res/values/saved_posts_strings.xml
+++ b/feature/metis/conversation/src/main/res/values/saved_posts_strings.xml
@@ -10,6 +10,7 @@
     <string name="saved_posts_empty_state_title">No saved messages with status \'%1$s\'</string>
 
     <string name="saved_posts_context_private_chat">Chat</string>
+    <string name="saved_posts_context_channel">Channel</string>
     <string name="saved_posts_context_thread">Thread</string>
 
     <string name="saved_posts_action_change_status">Mark as \'%1$s\'</string>

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/ISavedPost.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/ISavedPost.kt
@@ -14,7 +14,7 @@ interface ISavedPost : IBasePost {
     @Serializable
     data class SimpleConversationInfo(
         val id: Long,
-        val title: String,
+        val title: String?,
         val type: ConversationType
     ) {
         @Serializable


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
For some conversations the title of the conversation info for a SavedPostDTO was null.

This PR closes #463 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Made title nullable


### Steps for testing
- Log in to TS0 as test_user_2
- Go to "General Testing Course"
- Click on "Saved posts > In Progress"
- See no loading error
