### PR TITLE
`Improvement`: Update unread counter when clicking notification "Mark as read"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,7 @@
             android:resource="@string/asset_statements" />
 
         <receiver android:name="de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.reply.ReplyReceiver" />
+        <receiver android:name="de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.mark_as_read.MarkAsReadReceiver" />
         <receiver android:name="de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.delete.DeleteNotificationReceiver" />
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,7 +78,7 @@
             android:name="asset_statements"
             android:resource="@string/asset_statements" />
 
-        <receiver android:name="de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.ReplyReceiver" />
-        <receiver android:name="de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.DeleteNotificationReceiver" />
+        <receiver android:name="de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.reply.ReplyReceiver" />
+        <receiver android:name="de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.delete.DeleteNotificationReceiver" />
     </application>
 </manifest>

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationDao.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationDao.kt
@@ -65,7 +65,7 @@ interface PushCommunicationDao {
                     notificationTypeString = artemisNotification.type.toString(),
                     courseTitle = content.courseName,
                     containerTitle = content.channelName,
-                    target = artemisNotification.target,
+                    targetString = artemisNotification.target,
                     conversationTypeString = content.conversationType?.rawValue
                 )
 

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationDao.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationDao.kt
@@ -91,6 +91,7 @@ interface PushCommunicationDao {
     @Transaction
     suspend fun insertSelfMessage(
         parentId: Long,
+        authorLoginName: String,
         authorName: String,
         authorImageUrl: String?,
         body: String,
@@ -101,7 +102,7 @@ interface PushCommunicationDao {
                 CommunicationMessageEntity(
                     communicationParentId = parentId,
                     text = body,
-                    authorId = "self",      // TODO
+                    authorId = authorLoginName,
                     authorName = authorName,
                     authorImageUrl = authorImageUrl,
                     date = date

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationEntity.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationEntity.kt
@@ -5,6 +5,8 @@ import androidx.room.Entity
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.CommunicationNotificationType
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.ReplyPostCommunicationNotificationType
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.StandalonePostCommunicationNotificationType
+import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.target.CommunicationPostTarget
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
 
 /**
  * A communication grouping for push notifications.
@@ -29,7 +31,7 @@ data class PushCommunicationEntity(
     @ColumnInfo(name = "container_title")
     val containerTitle: String?,
     @ColumnInfo(name = "target")
-    val target: String,
+    val targetString: String,
     @ColumnInfo(name = "chat_type")
     val conversationTypeString: String?,
 ) {
@@ -43,4 +45,7 @@ data class PushCommunicationEntity(
             } catch (e: IllegalArgumentException) {
                 ReplyPostCommunicationNotificationType.valueOf(notificationTypeString)
             }
+
+    val target: CommunicationPostTarget
+        get() = NotificationTargetManager.getCommunicationNotificationTarget(targetString)
 }

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/notification_model/ArtemisNotification.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/notification_model/ArtemisNotification.kt
@@ -1,6 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.feature.push.notification_model
 
-import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.NotificationTargetManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
 import kotlinx.datetime.Instant
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.KSerializer

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/push_module.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/push_module.kt
@@ -15,6 +15,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.Work
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.CommunicationNotificationManagerImpl
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.MiscNotificationManager
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.NotificationManagerImpl
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.mark_as_read.MarkConversationAsReadWorker
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.reply.UpdateReplyNotificationWorker
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.network.NotificationSettingsService
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.network.impl.NotificationSettingsServiceImpl
@@ -52,6 +53,7 @@ val pushModule = module {
     workerOf(::UploadPushNotificationDeviceConfigurationWorker)
     workerOf(::UnsubscribeFromNotificationsWorker)
     workerOf(::UpdateReplyNotificationWorker)
+    workerOf(::MarkConversationAsReadWorker)
 
     single<NotificationSettingsService> {
         NotificationSettingsServiceImpl(

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/push_module.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/push_module.kt
@@ -15,7 +15,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.Work
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.CommunicationNotificationManagerImpl
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.MiscNotificationManager
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.NotificationManagerImpl
-import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.UpdateReplyNotificationWorker
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.reply.UpdateReplyNotificationWorker
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.network.NotificationSettingsService
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.network.impl.NotificationSettingsServiceImpl
 import de.tum.informatics.www1.artemis.native_app.feature.push.ui.PushNotificationSettingsViewModel

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/CommunicationNotificationManager.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/CommunicationNotificationManager.kt
@@ -14,6 +14,7 @@ interface CommunicationNotificationManager {
      */
     suspend fun addSelfMessage(
         parentId: Long,
+        authorLoginName: String,
         authorName: String,
         authorImageUrl: String?,
         body: String,

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/PushNotificationHandlerImpl.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/PushNotificationHandlerImpl.kt
@@ -13,7 +13,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.push.notification_mode
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.ReplyPostCommunicationNotificationType
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.NotificationManager
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.PushNotificationHandler
-import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.NotificationTargetManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/BaseCommunicationNotificationReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/BaseCommunicationNotificationReceiver.kt
@@ -3,11 +3,10 @@ package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.not
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import androidx.room.withTransaction
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
 import de.tum.informatics.www1.artemis.native_app.feature.push.PushCommunicationDatabaseProvider
+import de.tum.informatics.www1.artemis.native_app.feature.push.communication_notification_model.PushCommunicationEntity
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
-import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
+import kotlinx.coroutines.runBlocking
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
@@ -22,27 +21,14 @@ abstract class BaseCommunicationNotificationReceiver : BroadcastReceiver(), Koin
 
     override fun onReceive(context: Context, intent: Intent) {
         val parentId = intent.getLongExtra(PARENT_ID, 0)
-        onReceive(parentId, context, intent)
+        val pushCommunicationEntity = runBlocking { getCommunication(parentId) }
+        onReceive(pushCommunicationEntity, context, intent)
     }
 
-    abstract fun onReceive(parentId: Long, context: Context, intent: Intent)
-
-
-
-    protected suspend fun getMetisContext(parentId: Long): MetisContext.Conversation {
-        return getMetisContextAndPostId(parentId).first
-    }
-
-    protected suspend fun getMetisContextAndPostId(parentId: Long): Pair<MetisContext.Conversation, Long> {
+    private suspend fun getCommunication(parentId: Long): PushCommunicationEntity {
         val pushCommunicationDatabaseProvider: PushCommunicationDatabaseProvider = get()
-        return pushCommunicationDatabaseProvider.database.withTransaction {
-            val communication = pushCommunicationDatabaseProvider.pushCommunicationDao.getCommunication(parentId)
-
-            val metisTarget = NotificationTargetManager.getCommunicationNotificationTarget(
-                communication.target
-            )
-
-            metisTarget.metisContext to metisTarget.postId
-        }
+        return pushCommunicationDatabaseProvider.pushCommunicationDao.getCommunication(parentId)
     }
+
+    abstract fun onReceive(communicationEntity: PushCommunicationEntity, context: Context, intent: Intent)
 }

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/BaseCommunicationNotificationReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/BaseCommunicationNotificationReceiver.kt
@@ -1,18 +1,40 @@
 package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager
 
 import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
 import androidx.room.withTransaction
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
 import de.tum.informatics.www1.artemis.native_app.feature.push.PushCommunicationDatabaseProvider
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
 abstract class BaseCommunicationNotificationReceiver : BroadcastReceiver(), KoinComponent {
 
+    companion object {
+        /** The id of the communication entity that this notification belongs to. */
+        const val PARENT_ID = "parent_id"
+    }
+
+    protected val communicationNotificationManager: CommunicationNotificationManager = get()
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val parentId = intent.getLongExtra(PARENT_ID, 0)
+        onReceive(parentId, context, intent)
+    }
+
+    abstract fun onReceive(parentId: Long, context: Context, intent: Intent)
+
+
+
+    protected suspend fun getMetisContext(parentId: Long): MetisContext.Conversation {
+        return getMetisContextAndPostId(parentId).first
+    }
+
     protected suspend fun getMetisContextAndPostId(parentId: Long): Pair<MetisContext.Conversation, Long> {
         val pushCommunicationDatabaseProvider: PushCommunicationDatabaseProvider = get()
-
         return pushCommunicationDatabaseProvider.database.withTransaction {
             val communication = pushCommunicationDatabaseProvider.pushCommunicationDao.getCommunication(parentId)
 

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/BaseCommunicationNotificationReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/BaseCommunicationNotificationReceiver.kt
@@ -1,0 +1,26 @@
+package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager
+
+import android.content.BroadcastReceiver
+import androidx.room.withTransaction
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
+import de.tum.informatics.www1.artemis.native_app.feature.push.PushCommunicationDatabaseProvider
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+
+abstract class BaseCommunicationNotificationReceiver : BroadcastReceiver(), KoinComponent {
+
+    protected suspend fun getMetisContextAndPostId(parentId: Long): Pair<MetisContext.Conversation, Long> {
+        val pushCommunicationDatabaseProvider: PushCommunicationDatabaseProvider = get()
+
+        return pushCommunicationDatabaseProvider.database.withTransaction {
+            val communication = pushCommunicationDatabaseProvider.pushCommunicationDao.getCommunication(parentId)
+
+            val metisTarget = NotificationTargetManager.getCommunicationNotificationTarget(
+                communication.target
+            )
+
+            metisTarget.metisContext to metisTarget.postId
+        }
+    }
+}

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
@@ -94,6 +94,7 @@ internal class CommunicationNotificationManagerImpl(
 
     override suspend fun addSelfMessage(
         parentId: Long,
+        authorLoginName: String,
         authorName: String,
         authorImageUrl: String?,
         body: String,
@@ -101,6 +102,7 @@ internal class CommunicationNotificationManagerImpl(
     ) {
         dbProvider.pushCommunicationDao.insertSelfMessage(
             parentId = parentId,
+            authorLoginName = authorLoginName,
             authorName = authorName,
             authorImageUrl = authorImageUrl,
             body = body,

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
@@ -148,7 +148,7 @@ internal class CommunicationNotificationManagerImpl(
             ArtemisNotificationChannel.CommunicationNotificationChannel
 
         val metisTarget =
-            NotificationTargetManager.getCommunicationNotificationTarget(communication.target)
+            NotificationTargetManager.getCommunicationNotificationTarget(communication.targetString)
 
         val notification = NotificationCompat.Builder(context, notificationChannel.id)
             .setStyle(buildMessagingStyle(communication, messages))

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
@@ -29,6 +29,10 @@ import de.tum.informatics.www1.artemis.native_app.feature.push.notification_mode
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.ReplyPostCommunicationNotificationType
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.parentId
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.delete.DeleteNotificationReceiver
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.reply.ReplyReceiver
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.toCircleShape
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/MiscNotificationManager.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/MiscNotificationManager.kt
@@ -2,12 +2,13 @@ package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.not
 
 import android.content.Context
 import androidx.core.app.NotificationCompat
-import de.tum.informatics.www1.artemis.native_app.feature.push.ArtemisNotificationBuilder
 import de.tum.informatics.www1.artemis.native_app.core.common.ArtemisNotificationChannel
 import de.tum.informatics.www1.artemis.native_app.core.datastore.ArtemisNotificationManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.ArtemisNotificationBuilder
 import de.tum.informatics.www1.artemis.native_app.feature.push.R
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.ArtemisNotification
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.MiscNotificationType
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
 import kotlinx.coroutines.runBlocking
 
 internal class MiscNotificationManager(private val context: Context) : BaseNotificationManager {

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/UpdateReplyNotificationWorker.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/UpdateReplyNotificationWorker.kt
@@ -33,6 +33,7 @@ class UpdateReplyNotificationWorker(
 
                 communicationNotificationManager.addSelfMessage(
                     parentId = conversationId,
+                    authorLoginName = account.username ?: "self",
                     authorName = account.humanReadableName,
                     authorImageUrl = account.imageUrl,
                     body = content,

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/delete/DeleteNotificationReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/delete/DeleteNotificationReceiver.kt
@@ -1,24 +1,13 @@
 package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.delete
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.BaseCommunicationNotificationReceiver
 import kotlinx.coroutines.runBlocking
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 
-class DeleteNotificationReceiver : BroadcastReceiver(), KoinComponent {
+class DeleteNotificationReceiver : BaseCommunicationNotificationReceiver() {
 
-    companion object {
-        const val PARENT_ID = "parent_id"
-    }
-
-    override fun onReceive(context: Context, intent: Intent) {
-        val parentId = intent.getLongExtra(PARENT_ID, 0)
-
-        val communicationNotificationManager: CommunicationNotificationManager = get()
-
+    override fun onReceive(parentId: Long, context: Context, intent: Intent) {
         runBlocking {
             communicationNotificationManager.deleteCommunication(parentId)
         }

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/delete/DeleteNotificationReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/delete/DeleteNotificationReceiver.kt
@@ -2,14 +2,19 @@ package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.not
 
 import android.content.Context
 import android.content.Intent
+import de.tum.informatics.www1.artemis.native_app.feature.push.communication_notification_model.PushCommunicationEntity
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.BaseCommunicationNotificationReceiver
 import kotlinx.coroutines.runBlocking
 
 class DeleteNotificationReceiver : BaseCommunicationNotificationReceiver() {
 
-    override fun onReceive(parentId: Long, context: Context, intent: Intent) {
+    override fun onReceive(
+        communicationEntity: PushCommunicationEntity,
+        context: Context,
+        intent: Intent
+    ) {
         runBlocking {
-            communicationNotificationManager.deleteCommunication(parentId)
+            communicationNotificationManager.deleteCommunication(communicationEntity.parentId)
         }
     }
 }

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/delete/DeleteNotificationReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/delete/DeleteNotificationReceiver.kt
@@ -1,4 +1,4 @@
-package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager
+package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.delete
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkAsReadReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkAsReadReceiver.kt
@@ -8,6 +8,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
+import de.tum.informatics.www1.artemis.native_app.feature.push.communication_notification_model.PushCommunicationEntity
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.BaseCommunicationNotificationReceiver
 import kotlinx.coroutines.runBlocking
@@ -19,10 +20,16 @@ import org.koin.core.component.get
  */
 class MarkAsReadReceiver : BaseCommunicationNotificationReceiver() {
 
-    override fun onReceive(parentId: Long, context: Context, intent: Intent) {
-        val metisContext = runBlocking { getMetisContext(parentId) }
-        enqueueWorker(metisContext, context)
-        deleteNotification(parentId)
+    override fun onReceive(
+        communicationEntity: PushCommunicationEntity,
+        context: Context,
+        intent: Intent
+    ) {
+        enqueueWorker(
+            metisContext = communicationEntity.target.metisContext,
+            context = context
+        )
+        deleteNotification(communicationEntity.parentId)
     }
 
     private fun enqueueWorker(

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkAsReadReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkAsReadReceiver.kt
@@ -1,0 +1,59 @@
+package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.mark_as_read
+
+import android.content.Context
+import android.content.Intent
+import androidx.work.Constraints
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.BaseCommunicationNotificationReceiver
+import kotlinx.coroutines.runBlocking
+import org.koin.core.component.get
+
+/**
+ * onReceive will be called by the mark as read action of the notification.
+ * This receiver schedules a reply job to upload the reply.
+ */
+class MarkAsReadReceiver : BaseCommunicationNotificationReceiver() {
+
+    companion object {
+        const val PARENT_ID = "parent_id"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val parentId = intent.getLongExtra(PARENT_ID, 0)
+        val (metisContext, _) = runBlocking { getMetisContextAndPostId(parentId) }
+
+        enqueueWorker(metisContext, context)
+        deleteNotification(parentId)
+    }
+
+    private fun enqueueWorker(
+        metisContext: MetisContext.Conversation,
+        context: Context
+    ) {
+        val markAsReadWorkRequest = OneTimeWorkRequestBuilder<MarkConversationAsReadWorker>()
+            .setInputData(
+                workDataOf(
+                    MarkConversationAsReadWorker.KEY_COURSE_ID to metisContext.courseId,
+                    MarkConversationAsReadWorker.KEY_CONVERSATION_ID to metisContext.conversationId
+                )
+            )
+            .setConstraints(
+                Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+            )
+            .build()
+
+        WorkManager.getInstance(context).enqueue(markAsReadWorkRequest)
+    }
+
+    private fun deleteNotification(parentId: Long) {
+        val communicationNotificationManager: CommunicationNotificationManager = get()
+        runBlocking {
+            communicationNotificationManager.deleteCommunication(parentId = parentId)
+        }
+    }
+}

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkAsReadReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkAsReadReceiver.kt
@@ -19,14 +19,8 @@ import org.koin.core.component.get
  */
 class MarkAsReadReceiver : BaseCommunicationNotificationReceiver() {
 
-    companion object {
-        const val PARENT_ID = "parent_id"
-    }
-
-    override fun onReceive(context: Context, intent: Intent) {
-        val parentId = intent.getLongExtra(PARENT_ID, 0)
-        val (metisContext, _) = runBlocking { getMetisContextAndPostId(parentId) }
-
+    override fun onReceive(parentId: Long, context: Context, intent: Intent) {
+        val metisContext = runBlocking { getMetisContext(parentId) }
         enqueueWorker(metisContext, context)
         deleteNotification(parentId)
     }

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkAsReadReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkAsReadReceiver.kt
@@ -9,6 +9,7 @@ import androidx.work.WorkManager
 import androidx.work.workDataOf
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
 import de.tum.informatics.www1.artemis.native_app.feature.push.communication_notification_model.PushCommunicationEntity
+import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.StandalonePostCommunicationNotificationType
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.BaseCommunicationNotificationReceiver
 import kotlinx.coroutines.runBlocking
@@ -25,14 +26,17 @@ class MarkAsReadReceiver : BaseCommunicationNotificationReceiver() {
         context: Context,
         intent: Intent
     ) {
-        enqueueWorker(
-            metisContext = communicationEntity.target.metisContext,
-            context = context
-        )
+        // New thread replies do not increase a conversation's unread count, so we don't need to mark them as read.
+        if (communicationEntity.notificationType is StandalonePostCommunicationNotificationType) {
+            enqueueMarkConversationAsReadWorker(
+                metisContext = communicationEntity.target.metisContext,
+                context = context
+            )
+        }
         deleteNotification(communicationEntity.parentId)
     }
 
-    private fun enqueueWorker(
+    private fun enqueueMarkConversationAsReadWorker(
         metisContext: MetisContext.Conversation,
         context: Context
     ) {

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkConversationAsReadWorker.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkConversationAsReadWorker.kt
@@ -1,0 +1,44 @@
+package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.mark_as_read
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContextProvider
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.service.network.ConversationService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+class MarkConversationAsReadWorker(
+    appContext: Context,
+    params: WorkerParameters,
+    private val artemisContextProvider: ArtemisContextProvider,
+    private val conversationService: ConversationService,
+) : CoroutineWorker(appContext, params) {
+
+    companion object {
+        const val KEY_COURSE_ID = "course_id"
+        const val KEY_CONVERSATION_ID = "conversation_id"
+    }
+
+    override suspend fun doWork(): Result {
+        return withContext(Dispatchers.IO) {
+            val courseId = inputData.getLong(KEY_COURSE_ID, -1)
+            val conversationId = inputData.getLong(KEY_CONVERSATION_ID, -1)
+
+            if (courseId == -1L || conversationId == -1L) {
+                return@withContext Result.failure()
+            }
+
+            val artemisContext = artemisContextProvider.flow.first()
+            conversationService.markConversationAsRead(
+                courseId = courseId,
+                conversationId = conversationId,
+                authToken = artemisContext.authToken,
+                serverUrl = artemisContext.serverUrl
+            )
+
+            Result.success()
+        }
+    }
+}

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
@@ -1,27 +1,23 @@
 package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.reply
 
 import android.annotation.SuppressLint
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.RemoteInput
-import androidx.room.withTransaction
 import androidx.work.OneTimeWorkRequestBuilder
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.CreatePostService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.work.BaseCreatePostWorker
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
-import de.tum.informatics.www1.artemis.native_app.feature.push.PushCommunicationDatabaseProvider
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
-import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.BaseCommunicationNotificationReceiver
 import kotlinx.coroutines.runBlocking
-import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
 /**
  * onReceive will be called by the reply action of the notification.
  * This receiver schedules a reply job to upload the reply.
  */
-class ReplyReceiver : BroadcastReceiver(), KoinComponent {
+class ReplyReceiver : BaseCommunicationNotificationReceiver() {
 
     companion object {
         const val REPLY_INTENT_KEY = "reply_text_key"
@@ -82,20 +78,6 @@ class ReplyReceiver : BroadcastReceiver(), KoinComponent {
                     )
                     .build()
             )
-        }
-    }
-
-    private suspend fun getMetisContextAndPostId(parentId: Long): Pair<MetisContext.Conversation, Long> {
-        val pushCommunicationDatabaseProvider: PushCommunicationDatabaseProvider = get()
-
-        return pushCommunicationDatabaseProvider.database.withTransaction {
-            val communication = pushCommunicationDatabaseProvider.pushCommunicationDao.getCommunication(parentId)
-
-            val metisTarget = NotificationTargetManager.getCommunicationNotificationTarget(
-                communication.target
-            )
-
-            metisTarget.metisContext to metisTarget.postId
         }
     }
 }

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
@@ -1,4 +1,4 @@
-package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager
+package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.reply
 
 import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
@@ -12,6 +12,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.wor
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
 import de.tum.informatics.www1.artemis.native_app.feature.push.PushCommunicationDatabaseProvider
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
+import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util.NotificationTargetManager
 import kotlinx.coroutines.runBlocking
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
@@ -8,7 +8,6 @@ import androidx.work.OneTimeWorkRequestBuilder
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.CreatePostService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.work.BaseCreatePostWorker
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
-import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.BaseCommunicationNotificationReceiver
 import kotlinx.coroutines.runBlocking
 import org.koin.core.component.get
@@ -21,15 +20,12 @@ class ReplyReceiver : BaseCommunicationNotificationReceiver() {
 
     companion object {
         const val REPLY_INTENT_KEY = "reply_text_key"
-        const val PARENT_ID = "parent_id"
     }
 
     @SuppressLint("EnqueueWork")
-    override fun onReceive(context: Context, intent: Intent) {
+    override fun onReceive(parentId: Long, context: Context, intent: Intent) {
         val remoteInput = RemoteInput.getResultsFromIntent(intent) ?: return
-
         val response = remoteInput.getCharSequence(REPLY_INTENT_KEY).toString()
-        val parentId = intent.getLongExtra(PARENT_ID, 0)
 
         val (metisContext: MetisContext.Conversation, postId: Long) = runBlocking {
             getMetisContextAndPostId(parentId)
@@ -42,8 +38,6 @@ class ReplyReceiver : BaseCommunicationNotificationReceiver() {
                 response = response
             )
         }
-
-        val communicationNotificationManager: CommunicationNotificationManager = get()
 
         // Repop the notification to tell the OS we handled the notification
         runBlocking {

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/UpdateReplyNotificationWorker.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/UpdateReplyNotificationWorker.kt
@@ -1,4 +1,4 @@
-package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager
+package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.reply
 
 import android.content.Context
 import androidx.work.WorkerParameters

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/util/NotificationTargetManager.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/util/NotificationTargetManager.kt
@@ -1,4 +1,4 @@
-package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager
+package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util
 
 import android.app.PendingIntent
 import android.content.Context

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/util/bitmap_util.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/util/bitmap_util.kt
@@ -1,4 +1,4 @@
-package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager
+package de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.util
 
 import android.graphics.Bitmap
 import android.graphics.Canvas


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
Currently, the "Mark as read" action in a notification did just remove the notification from the local notification database. The unread counter of the conversation however did not update accordingly.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Created new Worker and Receiver for the markAsRead action
- Restructorings and Refactorings on the way of related notification code


### Steps for testing
1. Enable notifications
2. Receive a new post notification (eg by writing a new post from another user in the webapp)
3. Click on "Mark as read" in the notification
4. Notice that the unread counter of the conversation is updated accordingly

### Screenshots

https://github.com/user-attachments/assets/0c66a5e1-0ab0-446d-ace9-6f08e2563a92

