### PR TITLE
`Improvement`: Add section count to conversation overview

### DIFF
--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationList.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationList.kt
@@ -160,12 +160,13 @@ internal fun ConversationList(
     onToggleMuted: (conversationId: Long, muted: Boolean) -> Unit,
     trailingContent: LazyListScope.() -> Unit
 ) {
-    val listWithHeader: LazyListScope.(ConversationSectionState, String, String, Int, () -> Unit, @Composable () -> Unit) -> Unit =
-        { items, key, suffix, textRes, onClick, icon ->
+    val listWithHeader: LazyListScope.(ConversationSectionState, String, String, Int, Int?, () -> Unit, @Composable () -> Unit) -> Unit =
+        { items, key, suffix, textRes, count, onClick, icon ->
             conversationSectionHeader(
                 key = key,
                 text = textRes,
                 isExpanded = items.isExpanded,
+                conversationCount = count,
                 onClick = onClick,
                 icon = icon
             )
@@ -193,6 +194,7 @@ internal fun ConversationList(
                 SECTION_FAVORITES_KEY,
                 KEY_SUFFIX_FAVORITES,
                 R.string.conversation_overview_section_favorites,
+                conversationCollections.favorites.conversations.size,
                 toggleFavoritesExpanded,
                 { Icon(imageVector = Icons.Default.Favorite, contentDescription = null) }
             )
@@ -204,6 +206,7 @@ internal fun ConversationList(
                 SECTION_CHANNELS_KEY,
                 KEY_SUFFIX_CHANNELS,
                 R.string.conversation_overview_section_general_channels,
+                conversationCollections.channels.conversations.size,
                 toggleGeneralsExpanded
             ) { Icon(imageVector = Icons.Default.ChatBubble, contentDescription = null) }
         }
@@ -214,6 +217,7 @@ internal fun ConversationList(
                 SECTION_EXERCISES_KEY,
                 KEY_SUFFIX_EXERCISES,
                 R.string.conversation_overview_section_exercise_channels,
+                conversationCollections.exerciseChannels.conversations.size,
                 toggleExercisesExpanded
             ) { Icon(imageVector = Icons.AutoMirrored.Filled.List, contentDescription = null) }
         }
@@ -224,6 +228,7 @@ internal fun ConversationList(
                 SECTION_LECTURES_KEY,
                 KEY_SUFFIX_LECTURES,
                 R.string.conversation_overview_section_lecture_channels,
+                conversationCollections.lectureChannels.conversations.size,
                 toggleLecturesExpanded
             ) { Icon(imageVector = Icons.AutoMirrored.Filled.InsertDriveFile, contentDescription = null) }
         }
@@ -234,6 +239,7 @@ internal fun ConversationList(
                 SECTION_EXAMS_KEY,
                 KEY_SUFFIX_EXAMS,
                 R.string.conversation_overview_section_exam_channels,
+                conversationCollections.examChannels.conversations.size,
                 toggleExamsExpanded
             ) { Icon(imageVector = Icons.Default.School, contentDescription = null) }
         }
@@ -244,6 +250,7 @@ internal fun ConversationList(
                 SECTION_GROUPS_KEY,
                 KEY_SUFFIX_GROUPS,
                 R.string.conversation_overview_section_groups,
+                conversationCollections.groupChats.conversations.size,
                 toggleGroupChatsExpanded
             ) { Icon(imageVector = Icons.Default.Forum, contentDescription = null) }
         }
@@ -254,6 +261,7 @@ internal fun ConversationList(
                 SECTION_DIRECT_MESSAGES_KEY,
                 KEY_SUFFIX_PERSONAL,
                 R.string.conversation_overview_section_direct_messages,
+                conversationCollections.directChats.conversations.size,
                 togglePersonalConversationsExpanded
             ) { Icon(imageVector = Icons.AutoMirrored.Filled.Message, contentDescription = null) }
         }
@@ -264,6 +272,7 @@ internal fun ConversationList(
                 SECTION_HIDDEN_KEY,
                 KEY_SUFFIX_HIDDEN,
                 R.string.conversation_overview_section_hidden,
+                conversationCollections.hidden.conversations.size,
                 toggleHiddenExpanded
             ) { Icon(imageVector = Icons.Default.Archive, contentDescription = null) }
         }
@@ -273,6 +282,7 @@ internal fun ConversationList(
             SECTION_SAVED_POSTS_KEY,
             KEY_SUFFIX_SAVED_MESSAGES,
             R.string.conversation_overview_section_saved_posts,
+            null,
             toggleSavedPostsExpanded
         ) { Icon(imageVector = Icons.Default.Bookmark, contentDescription = null) }
 
@@ -284,6 +294,7 @@ private fun LazyListScope.conversationSectionHeader(
     key: String,
     @StringRes text: Int,
     isExpanded: Boolean,
+    conversationCount: Int? = null,
     onClick: () -> Unit,
     icon: @Composable () -> Unit
 ) {
@@ -307,7 +318,7 @@ private fun LazyListScope.conversationSectionHeader(
                     modifier = Modifier
                         .weight(1f)
                         .padding(start = 8.dp),
-                    text = stringResource(id = text),
+                    text = if (conversationCount != null) stringResource(id = text, conversationCount) else stringResource(id = text),
                     style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
                 )
             }

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationList.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationList.kt
@@ -160,13 +160,14 @@ internal fun ConversationList(
     onToggleMuted: (conversationId: Long, muted: Boolean) -> Unit,
     trailingContent: LazyListScope.() -> Unit
 ) {
-    val listWithHeader: LazyListScope.(ConversationSectionState, String, String, Int, Int?, () -> Unit, @Composable () -> Unit) -> Unit =
-        { items, key, suffix, textRes, count, onClick, icon ->
+    val listWithHeader: LazyListScope.(ConversationSectionState, String, String, Int, Int?, Long, () -> Unit, @Composable () -> Unit) -> Unit =
+        { items, key, suffix, textRes, count, unreadCount, onClick, icon ->
             conversationSectionHeader(
                 key = key,
                 text = textRes,
                 isExpanded = items.isExpanded,
                 conversationCount = count,
+                unreadCount = unreadCount,
                 onClick = onClick,
                 icon = icon
             )
@@ -195,6 +196,7 @@ internal fun ConversationList(
                 KEY_SUFFIX_FAVORITES,
                 R.string.conversation_overview_section_favorites,
                 conversationCollections.favorites.conversations.size,
+                conversationCollections.favorites.conversations.sumOf { it.unreadMessagesCount ?: 0 },
                 toggleFavoritesExpanded,
                 { Icon(imageVector = Icons.Default.Favorite, contentDescription = null) }
             )
@@ -207,6 +209,7 @@ internal fun ConversationList(
                 KEY_SUFFIX_CHANNELS,
                 R.string.conversation_overview_section_general_channels,
                 conversationCollections.channels.conversations.size,
+                conversationCollections.channels.conversations.sumOf { it.unreadMessagesCount ?: 0 },
                 toggleGeneralsExpanded
             ) { Icon(imageVector = Icons.Default.ChatBubble, contentDescription = null) }
         }
@@ -218,6 +221,7 @@ internal fun ConversationList(
                 KEY_SUFFIX_EXERCISES,
                 R.string.conversation_overview_section_exercise_channels,
                 conversationCollections.exerciseChannels.conversations.size,
+                conversationCollections.exerciseChannels.conversations.sumOf { it.unreadMessagesCount ?: 0 },
                 toggleExercisesExpanded
             ) { Icon(imageVector = Icons.AutoMirrored.Filled.List, contentDescription = null) }
         }
@@ -229,6 +233,7 @@ internal fun ConversationList(
                 KEY_SUFFIX_LECTURES,
                 R.string.conversation_overview_section_lecture_channels,
                 conversationCollections.lectureChannels.conversations.size,
+                conversationCollections.lectureChannels.conversations.sumOf { it.unreadMessagesCount ?: 0 },
                 toggleLecturesExpanded
             ) { Icon(imageVector = Icons.AutoMirrored.Filled.InsertDriveFile, contentDescription = null) }
         }
@@ -240,6 +245,7 @@ internal fun ConversationList(
                 KEY_SUFFIX_EXAMS,
                 R.string.conversation_overview_section_exam_channels,
                 conversationCollections.examChannels.conversations.size,
+                conversationCollections.examChannels.conversations.sumOf { it.unreadMessagesCount ?: 0 },
                 toggleExamsExpanded
             ) { Icon(imageVector = Icons.Default.School, contentDescription = null) }
         }
@@ -251,6 +257,7 @@ internal fun ConversationList(
                 KEY_SUFFIX_GROUPS,
                 R.string.conversation_overview_section_groups,
                 conversationCollections.groupChats.conversations.size,
+                conversationCollections.groupChats.conversations.sumOf { it.unreadMessagesCount ?: 0 },
                 toggleGroupChatsExpanded
             ) { Icon(imageVector = Icons.Default.Forum, contentDescription = null) }
         }
@@ -262,6 +269,7 @@ internal fun ConversationList(
                 KEY_SUFFIX_PERSONAL,
                 R.string.conversation_overview_section_direct_messages,
                 conversationCollections.directChats.conversations.size,
+                conversationCollections.directChats.conversations.sumOf { it.unreadMessagesCount ?: 0 },
                 togglePersonalConversationsExpanded
             ) { Icon(imageVector = Icons.AutoMirrored.Filled.Message, contentDescription = null) }
         }
@@ -273,6 +281,7 @@ internal fun ConversationList(
                 KEY_SUFFIX_HIDDEN,
                 R.string.conversation_overview_section_hidden,
                 conversationCollections.hidden.conversations.size,
+                conversationCollections.hidden.conversations.sumOf { it.unreadMessagesCount ?: 0 },
                 toggleHiddenExpanded
             ) { Icon(imageVector = Icons.Default.Archive, contentDescription = null) }
         }
@@ -283,6 +292,7 @@ internal fun ConversationList(
             KEY_SUFFIX_SAVED_MESSAGES,
             R.string.conversation_overview_section_saved_posts,
             null,
+            0,
             toggleSavedPostsExpanded
         ) { Icon(imageVector = Icons.Default.Bookmark, contentDescription = null) }
 
@@ -295,6 +305,7 @@ private fun LazyListScope.conversationSectionHeader(
     @StringRes text: Int,
     isExpanded: Boolean,
     conversationCount: Int? = null,
+    unreadCount: Long,
     onClick: () -> Unit,
     icon: @Composable () -> Unit
 ) {
@@ -322,6 +333,8 @@ private fun LazyListScope.conversationSectionHeader(
                     style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
                 )
             }
+
+            if (!isExpanded) UnreadMessages(unreadMessagesCount = unreadCount)
 
             IconButton(
                 modifier = Modifier.testTag(TEST_TAG_HEADER_EXPAND_ICON),
@@ -667,6 +680,7 @@ private fun UnreadMessages(modifier: Modifier = Modifier, unreadMessagesCount: L
         ) {
             Text(
                 text = unreadMessagesCount.toString(),
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )
         }

--- a/feature/metis/manage-conversations/src/main/res/values/conversation_overview_strings.xml
+++ b/feature/metis/manage-conversations/src/main/res/values/conversation_overview_strings.xml
@@ -13,14 +13,14 @@
     <string name="conversation_overview_conversation_item_mark_as_muted">Mute</string>
     <string name="conversation_overview_conversation_item_unmark_as_muted">Unmute</string>
 
-    <string name="conversation_overview_section_favorites">Favorites</string>
-    <string name="conversation_overview_section_general_channels">General</string>
-    <string name="conversation_overview_section_exercise_channels">Exercises</string>
-    <string name="conversation_overview_section_lecture_channels">Lectures</string>
-    <string name="conversation_overview_section_exam_channels">Exams</string>
-    <string name="conversation_overview_section_groups">Group Chats</string>
-    <string name="conversation_overview_section_direct_messages">Direct Messages</string>
-    <string name="conversation_overview_section_hidden">Archive</string>
+    <string name="conversation_overview_section_favorites">Favorites (%d)</string>
+    <string name="conversation_overview_section_general_channels">General (%d)</string>
+    <string name="conversation_overview_section_exercise_channels">Exercises (%d)</string>
+    <string name="conversation_overview_section_lecture_channels">Lectures (%d)</string>
+    <string name="conversation_overview_section_exam_channels">Exams (%d)</string>
+    <string name="conversation_overview_section_groups">Group Chats (%d)</string>
+    <string name="conversation_overview_section_direct_messages">Direct Messages (%d)</string>
+    <string name="conversation_overview_section_hidden">Archive (%d)</string>
     <string name="conversation_overview_section_saved_posts">Saved Messages</string>
 
     <string name="conversation_overview_section_add_channel_browse">Browse channels</string>

--- a/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/overview/ConversationOverviewE2eTest.kt
+++ b/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/overview/ConversationOverviewE2eTest.kt
@@ -32,6 +32,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversati
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.KEY_SUFFIX_GROUPS
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.KEY_SUFFIX_HIDDEN
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.KEY_SUFFIX_PERSONAL
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.SECTION_CHANNELS_KEY
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.SECTION_HIDDEN_KEY
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.TEST_TAG_CONVERSATION_LIST
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.TEST_TAG_HEADER_EXPAND_ICON
@@ -424,7 +425,7 @@ class ConversationOverviewE2eTest : ConversationBaseTest() {
         }
 
         composeTestRule.waitUntilAtLeastOneExists(
-            hasText(context.getString(R.string.conversation_overview_section_general_channels)),
+            hasTestTag(SECTION_CHANNELS_KEY),
             DefaultTimeoutMillis
         )
 


### PR DESCRIPTION
### Problem Description

The conversation count is currently missing in the conversation overview list, see #479 

### Changes

This PR adds a small change, that introduces conversation section counts for all sections except the saved post section.

### Steps for testing

Make sure the count is correctly reflected.

### Screenshots

![ConversationCount](https://github.com/user-attachments/assets/ea882d78-8516-48d0-822d-15be6602f213)
