### PR TITLE
Improvement - display title for announcements

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/material/colors/PostColors.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/material/colors/PostColors.kt
@@ -43,4 +43,7 @@ object PostColors {
 
     val unsentMessageText: Color
         @Composable get() = Color.Gray
+    val announcementTitle: Color
+        @Composable get() = MaterialTheme.colorScheme.primary
+
 }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/post/PostItem.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/post/PostItem.kt
@@ -270,6 +270,7 @@ fun PostItemMainContent(
     leadingContent: @Composable ColumnScope.() -> Unit = {},
     trailingContent: @Composable ColumnScope.() -> Unit = {}
 ) {
+    val hasTitle = post is IStandalonePost && post.title != null
     Column(
         modifier = modifier
     ) {
@@ -301,6 +302,24 @@ fun PostItemMainContent(
                 }
 
                 if (post?.content?.isNotEmpty() == true) {
+                    if (hasTitle) {
+                        val title = (post as IStandalonePost).title
+                        MarkdownText(
+                            markdown = remember(title, isPlaceholder) {
+                                if (isPlaceholder) {
+                                    PlaceholderContent
+                                } else title.orEmpty()
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .placeholder(visible = isPlaceholder),
+                            style = MaterialTheme.typography.titleMedium,
+                            onClick = onClick,
+                            onLongClick = onLongClick,
+                            color = PostColors.announcementTitle
+                        )
+                    }
+
                     MarkdownText(
                         markdown = remember(post.content, isPlaceholder) {
                             if (isPlaceholder) {


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
In the web application announcements display with its titles, but in the android app the titles are ignored and this can cause information loss for users.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
If StandalonePost has title, display.

### Steps for testing
Open a communication enabled course
Open announcement channel
Verify that Annoncement Titles are visible


### Screenshots
<img width="261" alt="Screenshot 2025-03-14 at 16 26 42" src="https://github.com/user-attachments/assets/a855b449-8873-409b-ab31-81ec2ca1aa5b" />

