### PR TITLE
`Chore`: Fix e2e tests reset database

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main, develop]
     paths-ignore:
-      - '*.md'
+      - '**.md'
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,7 +3,11 @@ name: Compile
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,10 +6,10 @@ on:
       - main
       - develop
     paths-ignore:
-      - '*.md'
+      - '**.md'
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,14 +41,8 @@ jobs:
         if: success() || failure()
         continue-on-error: true
 
-        # Sanity cleanup 2
-      - name: Print what is running on port 3306
-        run: sudo lsof -i:3306 || true
-        continue-on-error: true
-
-      - name: Stop anything still running on port 3306
-        run: sudo kill -9 $(sudo lsof -t -i:3306) || true
-        continue-on-error: true
+      - name: Remove mysql volume
+        run: docker volume rm artemis-mysql-data-android || exit 0
 
       - name: Launch docker containers
         run: docker compose -f docker/e2e-tests.yml up -d artemis-app-setup

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - main
       - develop
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,10 +6,10 @@ on:
       - main
       - develop
     paths-ignore:
-      - '*.md'
+      - '**.md'
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - main
       - develop
+    paths-ignore:
+      - '*.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
   workflow_dispatch:
 
 permissions:

--- a/docker/e2e-tests.yml
+++ b/docker/e2e-tests.yml
@@ -39,7 +39,7 @@ networks:
     name: artemis
 
 volumes:
-  artemis-mysql-data:
-    name: artemis-mysql-data
+  artemis-mysql-data-android:
+    name: artemis-mysql-data-android
   artemis-data:
     name: artemis-data

--- a/docker/mysql.yml
+++ b/docker/mysql.yml
@@ -7,7 +7,7 @@ services:
     container_name: artemis-mysql
     image: docker.io/library/mysql:9.0.1
     volumes:
-      - artemis-mysql-data:/var/lib/mysql
+      - artemis-mysql-data-android:/var/lib/mysql
     # DO NOT use this default file for production systems!
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: true
@@ -37,5 +37,6 @@ networks:
     name: artemis
 
 volumes:
-  artemis-mysql-data:
-    name: artemis-mysql-data
+  # To avoid any conflicts with other Artemis setups (eg on the self-hosted github action runners), we use a unique volume name
+  artemis-mysql-data-android:
+    name: artemis-mysql-data-android

--- a/feature/dashboard/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/dashboard/DashboardE2eTest.kt
+++ b/feature/dashboard/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/dashboard/DashboardE2eTest.kt
@@ -25,7 +25,6 @@ import de.tum.informatics.www1.artemis.native_app.feature.login.test.getAdminAcc
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.performTestLogin
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.testLoginModule
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -35,10 +34,6 @@ import org.koin.test.KoinTestRule
 import org.koin.test.get
 import org.robolectric.RobolectricTestRunner
 
-@Ignore("There seems to be a problem related to the docker files, where the mysql database is not " +
-        "reset properly. This causes the newly created courses by this E2e test to pile up and " +
-        "causes the server to take very long to return all the courses. This results in a timeout." +
-        "Issue: https://github.com/ls1intum/artemis-android/issues/169")
 @OptIn(ExperimentalTestApi::class)
 @Category(EndToEndTest::class)
 @RunWith(RobolectricTestRunner::class)

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/impl/SavedPostServiceImplE2eTest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/impl/SavedPostServiceImplE2eTest.kt
@@ -8,7 +8,6 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.Sav
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.SavedPostService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.SavedPostStatus
 import kotlinx.coroutines.test.runTest
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
@@ -17,7 +16,6 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
 
-@Ignore("Suddenly started failing: https://github.com/ls1intum/artemis-android/issues/370")
 @RunWith(RobolectricTestRunner::class)
 @Category(EndToEndTest::class)
 class SavedPostServiceImplTest : ConversationMessagesBaseTest() {

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,8 @@ We use both unit tests and end-to-end integration tests. Before running the end-
 - To run the end-to-end tests, first start artemis locally in docker: 
   - `docker compose -f docker/e2e-tests.yml up artemis-app-setup`
   - `./gradlew test -Dskip.unit-tests=true -Dskip.e2e=false -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true`
+  - **Note**: With the end-to-end tests, we create many new courses that might pile up and slow down the performance of the tests. 
+Consider cleaning the database by running `docker volume rm artemis-mysql-data-android` from time to time.
 
 
 For AndroidStudio, there are also preconfigured run configurations available. 

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ We use both unit tests and end-to-end integration tests. Before running the end-
   - `docker compose -f docker/e2e-tests.yml up artemis-app-setup`
   - `./gradlew test -Dskip.unit-tests=true -Dskip.e2e=false -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true`
   - **Note**: With the end-to-end tests, we create many new courses that might pile up and slow down the performance of the tests. 
-Consider cleaning the database by running  `docker volume rm artemis-mysql-data-android` from time to time.
+Consider cleaning the database by running `docker volume rm artemis-mysql-data-android` from time to time.
 
 
 For AndroidStudio, there are also preconfigured run configurations available. 

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ We use both unit tests and end-to-end integration tests. Before running the end-
   - `docker compose -f docker/e2e-tests.yml up artemis-app-setup`
   - `./gradlew test -Dskip.unit-tests=true -Dskip.e2e=false -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true`
   - **Note**: With the end-to-end tests, we create many new courses that might pile up and slow down the performance of the tests. 
-Consider cleaning the database by running `docker volume rm artemis-mysql-data-android` from time to time.
+Consider cleaning the database by running  `docker volume rm artemis-mysql-data-android` from time to time.
 
 
 For AndroidStudio, there are also preconfigured run configurations available. 


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
We want to reset the artemis mySQL database, because we create many courses with our e2e tests. Without this reset, there would be many courses piling up, slowing down the tests (and causing some of them to fail / time out).

A similar approach was already done previously in https://github.com/ls1intum/Artemis/pull/8044.

This PR closes #169 and #370 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Added removal of mysql docker volume to e2e workflow
- Just to be sure we do not mess with other workflows that rely on the persistence of the volume, we created a separate one just for the android e2e tests
