### PR TITLE
`Chore`: Update api routes for e2e tests

### DIFF
--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
@@ -18,79 +18,79 @@ sealed class Api(
 
     // With 8.0.0 API changes:
 
-//    data object Core: Api(api, "core") {
-//        data object Public : Api(*Core.path, "public")
-//        data object Courses : Api(*Core.path, "courses")
-//    }
-//
-//    data object Communication: Api(api, "communication") {
-//        data object Courses : Api(*Communication.path, "courses")
-//        data object NotificationSettings : Api(*Communication.path, "notification-settings")
-//        data object PushNotification : Api(*Communication.path, "push_notification")
-//        data object SavedPosts : Api(*Communication.path, "saved-posts")
-//    }
-//
-//    data object Lecture: Api(api, "lecture") {
-//        data object Lectures : Api(*Lecture.path, "lectures")
-//    }
-//
-//    data object Exercise: Api(api, "exercise") {
-//        data object Exercises : Api(*Exercise.path, "exercises")
-//    }
-//
-//    data object Text: Api(api, "text") {
-//        data object TextExercises : Api(*Text.path, "text-exercises")
-//    }
-//
-//    data object Modeling: Api(api, "modeling") {
-//        data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
-//    }
-//
-//    data object Programming: Api(api, "programming") {
-//        data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
-//    }
-//
-//    data object Quiz: Api(api, "quiz") {
-//        data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
-//    }
-
-
-    // Prior to 8.0.0 API changes:
-    // Active for now to be compatible with the artemis-latest docker version used for e2e tests
-
-    data object Core: Api(api) {
+    data object Core: Api(api, "core") {
         data object Public : Api(*Core.path, "public")
         data object Courses : Api(*Core.path, "courses")
     }
 
-    data object Communication: Api(api) {
+    data object Communication: Api(api, "communication") {
         data object Courses : Api(*Communication.path, "courses")
         data object NotificationSettings : Api(*Communication.path, "notification-settings")
         data object PushNotification : Api(*Communication.path, "push_notification")
         data object SavedPosts : Api(*Communication.path, "saved-posts")
     }
 
-    data object Lecture: Api(api) {
+    data object Lecture: Api(api, "lecture") {
         data object Lectures : Api(*Lecture.path, "lectures")
     }
 
-    data object Exercise: Api(api) {
+    data object Exercise: Api(api, "exercise") {
         data object Exercises : Api(*Exercise.path, "exercises")
     }
 
-    data object Text: Api(api) {
+    data object Text: Api(api, "text") {
         data object TextExercises : Api(*Text.path, "text-exercises")
     }
 
-    data object Modeling: Api(api) {
+    data object Modeling: Api(api, "modeling") {
         data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
     }
 
-    data object Programming: Api(api) {
+    data object Programming: Api(api, "programming") {
         data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
     }
 
-    data object Quiz: Api(api) {
+    data object Quiz: Api(api, "quiz") {
         data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
     }
+
+
+    // Prior to 8.0.0 API changes:
+    // Uncomment this block and remove the block above to run the app with a Artemis version lower than 8.0.0
+
+//    data object Core: Api(api) {
+//        data object Public : Api(*Core.path, "public")
+//        data object Courses : Api(*Core.path, "courses")
+//    }
+//
+//    data object Communication: Api(api) {
+//        data object Courses : Api(*Communication.path, "courses")
+//        data object NotificationSettings : Api(*Communication.path, "notification-settings")
+//        data object PushNotification : Api(*Communication.path, "push_notification")
+//        data object SavedPosts : Api(*Communication.path, "saved-posts")
+//    }
+//
+//    data object Lecture: Api(api) {
+//        data object Lectures : Api(*Lecture.path, "lectures")
+//    }
+//
+//    data object Exercise: Api(api) {
+//        data object Exercises : Api(*Exercise.path, "exercises")
+//    }
+//
+//    data object Text: Api(api) {
+//        data object TextExercises : Api(*Text.path, "text-exercises")
+//    }
+//
+//    data object Modeling: Api(api) {
+//        data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
+//    }
+//
+//    data object Programming: Api(api) {
+//        data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
+//    }
+//
+//    data object Quiz: Api(api) {
+//        data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
+//    }
 }

--- a/docker/create_test_users.sh
+++ b/docker/create_test_users.sh
@@ -5,7 +5,7 @@ serverUrl=$1
 jwtRegex="jwt=((\w|\d|\.|-)*)"
 
 responseHeaders=$(
-  curl -X POST http://"$serverUrl"/api/public/authenticate \
+  curl -X POST http://"$serverUrl"/api/core/public/authenticate \
     -H "Content-Type: application/json" \
     -d '{"username":"artemis_admin","password":"artemis_admin","rememberMe":true}' \
     -i
@@ -17,7 +17,7 @@ adminJwt=${BASH_REMATCH[1]}
 
 for i in 1 2 3
 do
-  curl -X POST http://"$serverUrl"/api/admin/users \
+  curl -X POST http://"$serverUrl"/api/core/admin/users \
   -H "Content-Type: application/json" \
   -H "Cookie: jwt=${adminJwt};" \
   -d '{"authorities":["ROLE_USER"],"login":"aa0'${i}'aaa","email":"test_user'${i}'@example.com","firstName":"Test","lastName":"User'${i}'","guidedTourSettings":[],"groups":["default"],"password":"test_user_'${i}'_password"}'


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The Artemis docker image `latest` (see https://github.com/ls1intum/Artemis/pkgs/container/artemis), now uses the API endpoints of Artemis 8.0. As our e2e tests use this docker image, we need to adapt the `Api`  to use the 8.0 endpoints by default.

