### PR TITLE
`Chore`: Adapt Announcement Title Styling

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/material/colors/PostColors.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/material/colors/PostColors.kt
@@ -43,7 +43,4 @@ object PostColors {
 
     val unsentMessageText: Color
         @Composable get() = Color.Gray
-    val announcementTitle: Color
-        @Composable get() = MaterialTheme.colorScheme.primary
-
 }

--- a/feature/metis/conversation/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/shared/ui/post/PostMainContent.kt
+++ b/feature/metis/conversation/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/shared/ui/post/PostMainContent.kt
@@ -122,7 +122,6 @@ fun PostItemMainContent(
                                     text = it,
                                     modifier = Modifier.fillMaxWidth(),
                                     style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                                    color = PostColors.announcementTitle
                                 )
                             }
                         }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The post title on mobile clients was previously using a blue color to align with the web. However, as discussed in [this PR](https://github.com/ls1intum/artemis-ios/pull/305), this color choice could be misinterpreted as indicating a clickable link. This behavior was inconsistent with the intended design and could lead to user confusion.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
The title color change to base text color

### Steps for testing

1. Log in to Artemis.
2. Navigate to a course with active communication.
3. Open the announcement channel.
4. Verify that the post title: Uses the base text color (not blue).

### Screenshots
<img width="267" alt="Screenshot 2025-03-21 at 21 00 43" src="https://github.com/user-attachments/assets/786bc00f-6ae8-47e6-957b-2d5a66203db5" />
