### PR TITLE
`Chore`: Use Stateflow instead of cold Flow in ArtemisContextProvider

### DIFF
--- a/core/common/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/common/artemis_context/ArtemisContextProvider.kt
+++ b/core/common/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/common/artemis_context/ArtemisContextProvider.kt
@@ -1,8 +1,8 @@
 package de.tum.informatics.www1.artemis.native_app.core.common.artemis_context
 
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface ArtemisContextProvider {
 
-    val flow: Flow<ArtemisContext>
+    val stateFlow: StateFlow<ArtemisContext>
 }

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/impl/ArtemisContextBasedServiceImpl.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/impl/ArtemisContextBasedServiceImpl.kt
@@ -18,7 +18,6 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 
@@ -31,9 +30,14 @@ abstract class ArtemisContextBasedServiceImpl(
 
     override val onReloadRequired: Flow<Unit> = artemisContextProvider.stateFlow.map { Unit }
 
-    suspend fun artemisContext(): ArtemisContext = artemisContextProvider.stateFlow.first()
-    suspend fun serverUrl(): String = artemisContext().serverUrl
-    suspend fun authToken(): String = artemisContext().authToken
+    val artemisContext: ArtemisContext
+        get() = artemisContextProvider.stateFlow.value
+
+    val serverUrl: String
+        get() = artemisContext.serverUrl
+
+    val authToken: String
+        get() = artemisContext.authToken
 
     suspend inline fun <reified T: Any>getRequest(
         contentType: ContentType = ContentType.Application.Json,
@@ -80,10 +84,10 @@ abstract class ArtemisContextBasedServiceImpl(
         crossinline block: HttpRequestBuilder.() -> Unit
     ): NetworkResponse<T> {
         return performNetworkCall {
-            val response = ktorProvider.ktorClient.request(serverUrl()) {
+            val response = ktorProvider.ktorClient.request(serverUrl) {
                 block()
                 contentType(contentType)
-                cookieAuth(authToken())
+                cookieAuth(authToken)
             }
 
             val requestString = "${response.request.method} ${response.request.url}"

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/impl/ArtemisContextBasedServiceImpl.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/impl/ArtemisContextBasedServiceImpl.kt
@@ -29,9 +29,9 @@ abstract class ArtemisContextBasedServiceImpl(
     private val artemisContextProvider: ArtemisContextProvider,
 ) : ArtemisContextBasedService {
 
-    override val onReloadRequired: Flow<Unit> = artemisContextProvider.flow.map { Unit }
+    override val onReloadRequired: Flow<Unit> = artemisContextProvider.stateFlow.map { Unit }
 
-    suspend fun artemisContext(): ArtemisContext = artemisContextProvider.flow.first()
+    suspend fun artemisContext(): ArtemisContext = artemisContextProvider.stateFlow.first()
     suspend fun serverUrl(): String = artemisContext().serverUrl
     suspend fun authToken(): String = artemisContext().authToken
 

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/network/impl/AccountDataServiceImpl.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/network/impl/AccountDataServiceImpl.kt
@@ -37,14 +37,14 @@ internal class AccountDataServiceImpl(
             }
         }.onSuccess { account ->
             context.accountDataCache.edit { data ->
-                data[getAccountDataCacheKey(authToken())] = jsonProvider.applicationJsonConfiguration.encodeToString(account)
+                data[getAccountDataCacheKey(authToken)] = jsonProvider.applicationJsonConfiguration.encodeToString(account)
             }
         }
     }
 
     override suspend fun getCachedAccountData(): Account? {
         val cacheData = context.accountDataCache.data.first()
-        val cacheKey = getAccountDataCacheKey(authToken())
+        val cacheKey = getAccountDataCacheKey(authToken)
         val cacheEntry = cacheData[cacheKey]
         if (cacheEntry != null) {
             try {

--- a/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/impl/ArtemisContextProviderImpl.kt
+++ b/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/impl/ArtemisContextProviderImpl.kt
@@ -4,15 +4,18 @@ import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.Ar
 import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContextProvider
 import de.tum.informatics.www1.artemis.native_app.core.datastore.AccountService
 import de.tum.informatics.www1.artemis.native_app.core.datastore.ServerConfigurationService
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 
 class ArtemisContextProviderImpl(
     serverConfigurationService: ServerConfigurationService,
     accountService: AccountService,
 ) : ArtemisContextProvider {
 
-    override val flow: Flow<ArtemisContext> = combine(
+    override val stateFlow: StateFlow<ArtemisContext> = combine(
         serverConfigurationService.serverUrl,
         accountService.authenticationData
     ) { serverUrl, authData ->
@@ -25,6 +28,5 @@ class ArtemisContextProviderImpl(
                 username = authData.username
             )
         }
-
-    }
+    }.stateIn(MainScope(), SharingStarted.Eagerly, ArtemisContext.Empty)
 }

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/LocalArtemisContextProvider.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/LocalArtemisContextProvider.kt
@@ -6,15 +6,15 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContext
 import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContextProvider
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 val LocalArtemisContextProvider: ProvidableCompositionLocal<ArtemisContextProvider> = compositionLocalOf {
     EmptyArtemisContextProvider
 }
 
 private object EmptyArtemisContextProvider : ArtemisContextProvider {
-    override val flow = emptyFlow<ArtemisContext>()
+    override val stateFlow = MutableStateFlow(ArtemisContext.Empty)
 }
 
 @Composable
-fun ArtemisContextProvider.collectArtemisContextAsState() = this.flow.collectAsState(ArtemisContext.Empty)
+fun ArtemisContextProvider.collectArtemisContextAsState() = this.stateFlow.collectAsState(ArtemisContext.Empty)

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/LocalArtemisContextProvider.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/LocalArtemisContextProvider.kt
@@ -17,4 +17,4 @@ private object EmptyArtemisContextProvider : ArtemisContextProvider {
 }
 
 @Composable
-fun ArtemisContextProvider.collectArtemisContextAsState() = this.stateFlow.collectAsState(ArtemisContext.Empty)
+fun ArtemisContextProvider.collectArtemisContextAsState() = this.stateFlow.collectAsState()

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/remote_images/impl/ArtemisImageProviderImpl.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/remote_images/impl/ArtemisImageProviderImpl.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.LocalContext
 import coil.ImageLoader
 import coil3.request.ImageRequest
 import coil3.request.ImageResult
+import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContext
 import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContextProvider
 import de.tum.informatics.www1.artemis.native_app.core.data.service.Api
 import de.tum.informatics.www1.artemis.native_app.core.ui.collectArtemisContextAsState
@@ -15,27 +16,24 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.remote_images.ArtemisI
 import de.tum.informatics.www1.artemis.native_app.core.ui.remote_images.BaseImageProvider
 import io.ktor.http.URLBuilder
 import io.ktor.http.appendPathSegments
-import kotlinx.coroutines.flow.first
 
 class ArtemisImageProviderImpl(
     private val artemisContextProvider: ArtemisContextProvider,
     private val imageProvider: BaseImageProvider
 ) : ArtemisImageProvider {
 
-    private suspend fun artemisContext() = artemisContextProvider.stateFlow.first()
+    private val artemisContext: ArtemisContext
+        get() = artemisContextProvider.stateFlow.value
 
     override suspend fun loadArtemisImage(context: Context, imagePath: String): ImageResult {
-        val serverUrl = artemisContext().serverUrl
-        val authToken = artemisContext().authToken
-
-        val imageUrl = URLBuilder(serverUrl)
+        val imageUrl = URLBuilder(artemisContext.serverUrl)
             .appendPathSegments(*Api.Core.UploadedImage.path)
             .appendPathSegments(imagePath)
             .buildString()
         val request = imageProvider.createImageRequest(
             context = context,
             imageUrl = imageUrl,
-            authorizationToken = authToken,
+            authorizationToken = artemisContext.authToken,
         )
 
         val loader = coil3.ImageLoader(context)

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/remote_images/impl/ArtemisImageProviderImpl.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/remote_images/impl/ArtemisImageProviderImpl.kt
@@ -22,7 +22,7 @@ class ArtemisImageProviderImpl(
     private val imageProvider: BaseImageProvider
 ) : ArtemisImageProvider {
 
-    private suspend fun artemisContext() = artemisContextProvider.flow.first()
+    private suspend fun artemisContext() = artemisContextProvider.stateFlow.first()
 
     override suspend fun loadArtemisImage(context: Context, imagePath: String): ImageResult {
         val serverUrl = artemisContext().serverUrl

--- a/feature/lecture-view/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureViewSnapshots.kt
+++ b/feature/lecture-view/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureViewSnapshots.kt
@@ -24,6 +24,8 @@ import de.tum.informatics.www1.artemis.native_app.core.websocket.test.LivePartic
 import de.tum.informatics.www1.artemis.native_app.feature.lectureview.service.LectureService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.service.network.impl.ChannelServiceStub
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
 
 @PlayStoreScreenshots
@@ -84,7 +86,7 @@ fun `Lecture - Overview`() {
         savedStateHandle = SavedStateHandle(),
         channelService = ChannelServiceStub,
         artemisContextProvider = object : ArtemisContextProvider {
-            override val flow: Flow<ArtemisContext> = emptyFlow()
+            override val stateFlow: StateFlow<ArtemisContext> = MutableStateFlow(ArtemisContext.Empty)
         },
         serverTimeService = ServerTimeServiceStub(),
         courseExerciseService = object : CourseExerciseService {

--- a/feature/lecture-view/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureViewSnapshots.kt
+++ b/feature/lecture-view/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureViewSnapshots.kt
@@ -6,8 +6,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
-import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContext
-import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContextProvider
 import de.tum.informatics.www1.artemis.native_app.core.data.NetworkResponse
 import de.tum.informatics.www1.artemis.native_app.core.data.ServerTimeServiceStub
 import de.tum.informatics.www1.artemis.native_app.core.data.service.network.CourseExerciseService
@@ -24,8 +22,6 @@ import de.tum.informatics.www1.artemis.native_app.core.websocket.test.LivePartic
 import de.tum.informatics.www1.artemis.native_app.feature.lectureview.service.LectureService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.service.network.impl.ChannelServiceStub
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
 
 @PlayStoreScreenshots
@@ -85,9 +81,6 @@ fun `Lecture - Overview`() {
         liveParticipationService = LiveParticipationServiceStub(),
         savedStateHandle = SavedStateHandle(),
         channelService = ChannelServiceStub,
-        artemisContextProvider = object : ArtemisContextProvider {
-            override val stateFlow: StateFlow<ArtemisContext> = MutableStateFlow(ArtemisContext.Empty)
-        },
         serverTimeService = ServerTimeServiceStub(),
         courseExerciseService = object : CourseExerciseService {
             override val onReloadRequired: Flow<Unit> = emptyFlow()

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureScreenUi.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureScreenUi.kt
@@ -26,8 +26,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.toRoute
 import de.tum.informatics.www1.artemis.native_app.core.model.lecture.Attachment
+import de.tum.informatics.www1.artemis.native_app.core.ui.LocalArtemisContextProvider
 import de.tum.informatics.www1.artemis.native_app.core.ui.LocalLinkOpener
 import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
+import de.tum.informatics.www1.artemis.native_app.core.ui.collectArtemisContextAsState
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.ArtemisTopAppBar
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.LinkBottomSheet
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.LinkBottomSheetState
@@ -119,7 +121,7 @@ internal fun LectureScreen(
 
     val lectureDataState by viewModel.lectureDataState.collectAsState()
     val serverUrl by viewModel.serverUrl.collectAsState()
-    val artemisContext by viewModel.artemisContext.collectAsState()
+    val artemisContext by LocalArtemisContextProvider.current.collectArtemisContextAsState()
 
     val lectureTitle = lectureDataState.bind<String?> { it.title }.orElse(null)
 

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureViewModel.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureViewModel.kt
@@ -89,7 +89,7 @@ internal class LectureViewModel(
             .stateIn(viewModelScope + coroutineContext, SharingStarted.Eagerly, DataState.Loading())
 
     val serverUrl: StateFlow<String> = serverUrlStateFlow(serverConfigurationService)
-    val artemisContext: StateFlow<ArtemisContext> = artemisContextProvider.flow
+    val artemisContext: StateFlow<ArtemisContext> = artemisContextProvider.stateFlow
         .stateIn(viewModelScope + coroutineContext, SharingStarted.Eagerly, ArtemisContext.Empty)
 
 

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureViewModel.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureViewModel.kt
@@ -2,8 +2,6 @@ package de.tum.informatics.www1.artemis.native_app.feature.lectureview
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContext
-import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.ArtemisContextProvider
 import de.tum.informatics.www1.artemis.native_app.core.common.transformLatest
 import de.tum.informatics.www1.artemis.native_app.core.data.DataState
 import de.tum.informatics.www1.artemis.native_app.core.data.filterSuccess
@@ -59,7 +57,6 @@ internal class LectureViewModel(
     private val liveParticipationService: LiveParticipationService,
     private val savedStateHandle: SavedStateHandle,
     private val channelService: ChannelService,
-    private val artemisContextProvider: ArtemisContextProvider,
     serverTimeService: ServerTimeService,
     courseExerciseService: CourseExerciseService,
     private val coroutineContext: CoroutineContext = EmptyCoroutineContext
@@ -89,8 +86,6 @@ internal class LectureViewModel(
             .stateIn(viewModelScope + coroutineContext, SharingStarted.Eagerly, DataState.Loading())
 
     val serverUrl: StateFlow<String> = serverUrlStateFlow(serverConfigurationService)
-    val artemisContext: StateFlow<ArtemisContext> = artemisContextProvider.stateFlow
-        .stateIn(viewModelScope + coroutineContext, SharingStarted.Eagerly, ArtemisContext.Empty)
 
 
     /**

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/lecture_module.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/lecture_module.kt
@@ -8,17 +8,16 @@ import org.koin.dsl.module
 val lectureModule = module {
     viewModel {
         LectureViewModel(
-            it.get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get()
+            lectureId = it.get(),
+            networkStatusProvider = get(),
+            lectureService = get(),
+            serverConfigurationService = get(),
+            accountService = get(),
+            liveParticipationService = get(),
+            savedStateHandle = get(),
+            channelService = get(),
+            serverTimeService = get(),
+            courseExerciseService = get()
         )
     }
     single<LectureService> { LectureServiceImpl(get()) }

--- a/feature/lecture-view/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lecture_view/LectureE2eTest.kt
+++ b/feature/lecture-view/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lecture_view/LectureE2eTest.kt
@@ -240,7 +240,6 @@ class LectureE2eTest : BaseComposeTest() {
             savedStateHandle = SavedStateHandle(),
             channelService = get(),
             serverTimeService = get(),
-            artemisContextProvider = get(),
             courseExerciseService = get(),
             coroutineContext = testDispatcher
         )

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/service/network/impl/ChannelServiceImpl.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/service/network/impl/ChannelServiceImpl.kt
@@ -103,7 +103,7 @@ class ChannelServiceImpl(
         conversationId: Long,
     ): NetworkResponse<Boolean> {
         return performNetworkCall {
-            ktorProvider.ktorClient.post(serverUrl()) {
+            ktorProvider.ktorClient.post(serverUrl) {
                 url {
                     appendPathSegments(
                         *Api.Communication.Courses.path,
@@ -114,10 +114,10 @@ class ChannelServiceImpl(
                     )
                 }
 
-                setBody(listOf(artemisContext().username))
+                setBody(listOf(artemisContext.username))
                 contentType(ContentType.Application.Json)
 
-                cookieAuth(authToken())
+                cookieAuth(authToken)
             }
                 .status
                 .isSuccess()

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/WorkManagerPushNotificationJobService.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/WorkManagerPushNotificationJobService.kt
@@ -43,7 +43,7 @@ internal class WorkManagerPushNotificationJobService(
     }
 
     override suspend fun scheduleUnsubscribeFromNotifications(firebaseToken: String) {
-        val artemisContext = artemisContextProvider.flow.first()
+        val artemisContext = artemisContextProvider.stateFlow.first()
         val request = defaultInternetWorkRequest<UnsubscribeFromNotificationsWorker>(
             Data
                 .Builder()

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkConversationAsReadWorker.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/mark_as_read/MarkConversationAsReadWorker.kt
@@ -30,7 +30,7 @@ class MarkConversationAsReadWorker(
                 return@withContext Result.failure()
             }
 
-            val artemisContext = artemisContextProvider.flow.first()
+            val artemisContext = artemisContextProvider.stateFlow.first()
             conversationService.markConversationAsRead(
                 courseId = courseId,
                 conversationId = conversationId,


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The ArtemisContext is much better represented by a hot StateFlow. This way, we do not always have to initialize a hot flow with `ArtemisContext.Empty`, resulting in unnecassary reloads and API calls. For example the following error log was often produced for loading profile pictures, because of this problem: `Error loading image: Failed to connect to localhost/127.0.0.1:80`

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Use hot stateFlow with `MainScope()` instead of cold flow for providing the ArtemisContext.

### Steps for testing
See that stuff related to the changed files still works and eg the before-mentioned error log is no longer produced.
