### PR TITLE
`Chore`: Switch to artemis.tum.de instance

### DIFF
--- a/app/src/tum/AndroidManifest.xml
+++ b/app/src/tum/AndroidManifest.xml
@@ -18,6 +18,7 @@
                 <data android:scheme="https"/>
                 <data android:host="artemis.ase.in.tum.de"/>
                 <data android:host="artemis.cit.tum.de"/>
+                <data android:host="artemis.tum.de"/>
 
                 <data android:pathPattern="/courses/.*" />
                 <data android:pathPattern="/courses/.*/exercises/.*/" />

--- a/app/src/unrestricted/AndroidManifest.xml
+++ b/app/src/unrestricted/AndroidManifest.xml
@@ -32,6 +32,7 @@
                 <data android:scheme="https"/>
                 <data android:host="artemis.ase.in.tum.de"/>
                 <data android:host="artemis.cit.tum.de"/>
+                <data android:host="artemis.tum.de"/>
                 <data android:host="artemis.codeability.uibk.ac.at"/>
                 <data android:host="artemis.praktomat.cs.kit.edu"/>
                 <data android:host="artemis-test0.artemis.in.tum.de"/>

--- a/build-logic/convention/src/main/kotlin/commonConfiguration/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/commonConfiguration/KotlinAndroid.kt
@@ -134,7 +134,7 @@ internal fun Project.configureReleaseTypeFlavors(
     }
 }
 
-private const val TUM_ARTEMIS_SERVER_URL = "https://artemis.cit.tum.de"
+private const val TUM_ARTEMIS_SERVER_URL = "https://artemis.tum.de"
 
 internal fun Project.configureInstanceSelectionFlavors(
     commonExtension: CommonExtension<*, *, *, *, *, *>,

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
@@ -18,55 +18,7 @@ sealed class Api(
 
     // With 8.0.0 API changes:
 
-//    data object Core: Api(api, "core") {
-//        data object Public : Api(*Core.path, "public")
-//        data object Courses : Api(*Core.path, "courses")
-//        data object Files : Api(*Core.path, "files")
-//
-//        /**
-//         * This is a special case, because for the 8.0 API the image path for eg profile picture or
-//         * course icons do not contain the "api(/core)/files" part, while prior to 8.0 it did.
-//         */
-//        // TODO: this can be removed once the app v2.0.0 is released
-//        data object UploadedImage : Api(*Files.path)
-//    }
-//
-//    data object Communication: Api(api, "communication") {
-//        data object Courses : Api(*Communication.path, "courses")
-//        data object NotificationSettings : Api(*Communication.path, "notification-settings")
-//        data object PushNotification : Api(*Communication.path, "push_notification")
-//        data object SavedPosts : Api(*Communication.path, "saved-posts")
-//    }
-//
-//    data object Lecture: Api(api, "lecture") {
-//        data object Lectures : Api(*Lecture.path, "lectures")
-//    }
-//
-//    data object Exercise: Api(api, "exercise") {
-//        data object Exercises : Api(*Exercise.path, "exercises")
-//    }
-//
-//    data object Text: Api(api, "text") {
-//        data object TextExercises : Api(*Text.path, "text-exercises")
-//    }
-//
-//    data object Modeling: Api(api, "modeling") {
-//        data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
-//    }
-//
-//    data object Programming: Api(api, "programming") {
-//        data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
-//    }
-//
-//    data object Quiz: Api(api, "quiz") {
-//        data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
-//    }
-
-
-    // Prior to 8.0.0 API changes:
-    // Uncomment this block and remove the block above to run the app with a Artemis version lower than 8.0.0
-
-    data object Core: Api(api) {
+    data object Core: Api(api, "core") {
         data object Public : Api(*Core.path, "public")
         data object Courses : Api(*Core.path, "courses")
         data object Files : Api(*Core.path, "files")
@@ -75,37 +27,85 @@ sealed class Api(
          * This is a special case, because for the 8.0 API the image path for eg profile picture or
          * course icons do not contain the "api(/core)/files" part, while prior to 8.0 it did.
          */
-        data object UploadedImage : Api("")
+        // TODO: this can be removed once the app v2.0.0 is released
+        data object UploadedImage : Api(*Files.path)
     }
 
-    data object Communication: Api(api) {
+    data object Communication: Api(api, "communication") {
         data object Courses : Api(*Communication.path, "courses")
         data object NotificationSettings : Api(*Communication.path, "notification-settings")
         data object PushNotification : Api(*Communication.path, "push_notification")
         data object SavedPosts : Api(*Communication.path, "saved-posts")
     }
 
-    data object Lecture: Api(api) {
+    data object Lecture: Api(api, "lecture") {
         data object Lectures : Api(*Lecture.path, "lectures")
     }
 
-    data object Exercise: Api(api) {
+    data object Exercise: Api(api, "exercise") {
         data object Exercises : Api(*Exercise.path, "exercises")
     }
 
-    data object Text: Api(api) {
+    data object Text: Api(api, "text") {
         data object TextExercises : Api(*Text.path, "text-exercises")
     }
 
-    data object Modeling: Api(api) {
+    data object Modeling: Api(api, "modeling") {
         data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
     }
 
-    data object Programming: Api(api) {
+    data object Programming: Api(api, "programming") {
         data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
     }
 
-    data object Quiz: Api(api) {
+    data object Quiz: Api(api, "quiz") {
         data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
     }
+
+
+    // Prior to 8.0.0 API changes:
+    // Uncomment this block and remove the block above to run the app with a Artemis version lower than 8.0.0
+
+//    data object Core: Api(api) {
+//        data object Public : Api(*Core.path, "public")
+//        data object Courses : Api(*Core.path, "courses")
+//        data object Files : Api(*Core.path, "files")
+//
+//        /**
+//         * This is a special case, because for the 8.0 API the image path for eg profile picture or
+//         * course icons do not contain the "api(/core)/files" part, while prior to 8.0 it did.
+//         */
+//        data object UploadedImage : Api("")
+//    }
+//
+//    data object Communication: Api(api) {
+//        data object Courses : Api(*Communication.path, "courses")
+//        data object NotificationSettings : Api(*Communication.path, "notification-settings")
+//        data object PushNotification : Api(*Communication.path, "push_notification")
+//        data object SavedPosts : Api(*Communication.path, "saved-posts")
+//    }
+//
+//    data object Lecture: Api(api) {
+//        data object Lectures : Api(*Lecture.path, "lectures")
+//    }
+//
+//    data object Exercise: Api(api) {
+//        data object Exercises : Api(*Exercise.path, "exercises")
+//    }
+//
+//    data object Text: Api(api) {
+//        data object TextExercises : Api(*Text.path, "text-exercises")
+//    }
+//
+//    data object Modeling: Api(api) {
+//        data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
+//    }
+//
+//    data object Programming: Api(api) {
+//        data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
+//    }
+//
+//    data object Quiz: Api(api) {
+//        data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
+//    }
 }

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
@@ -18,55 +18,7 @@ sealed class Api(
 
     // With 8.0.0 API changes:
 
-    data object Core: Api(api, "core") {
-        data object Public : Api(*Core.path, "public")
-        data object Courses : Api(*Core.path, "courses")
-        data object Files : Api(*Core.path, "files")
-
-        /**
-         * This is a special case, because for the 8.0 API the image path for eg profile picture or
-         * course icons do not contain the "api(/core)/files" part, while prior to 8.0 it did.
-         */
-        // TODO: this can be removed once the app v2.0.0 is released
-        data object UploadedImage : Api(*Files.path)
-    }
-
-    data object Communication: Api(api, "communication") {
-        data object Courses : Api(*Communication.path, "courses")
-        data object NotificationSettings : Api(*Communication.path, "notification-settings")
-        data object PushNotification : Api(*Communication.path, "push_notification")
-        data object SavedPosts : Api(*Communication.path, "saved-posts")
-    }
-
-    data object Lecture: Api(api, "lecture") {
-        data object Lectures : Api(*Lecture.path, "lectures")
-    }
-
-    data object Exercise: Api(api, "exercise") {
-        data object Exercises : Api(*Exercise.path, "exercises")
-    }
-
-    data object Text: Api(api, "text") {
-        data object TextExercises : Api(*Text.path, "text-exercises")
-    }
-
-    data object Modeling: Api(api, "modeling") {
-        data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
-    }
-
-    data object Programming: Api(api, "programming") {
-        data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
-    }
-
-    data object Quiz: Api(api, "quiz") {
-        data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
-    }
-
-
-    // Prior to 8.0.0 API changes:
-    // Uncomment this block and remove the block above to run the app with a Artemis version lower than 8.0.0
-
-//    data object Core: Api(api) {
+//    data object Core: Api(api, "core") {
 //        data object Public : Api(*Core.path, "public")
 //        data object Courses : Api(*Core.path, "courses")
 //        data object Files : Api(*Core.path, "files")
@@ -75,37 +27,85 @@ sealed class Api(
 //         * This is a special case, because for the 8.0 API the image path for eg profile picture or
 //         * course icons do not contain the "api(/core)/files" part, while prior to 8.0 it did.
 //         */
-//        data object UploadedImage : Api("")
+//        // TODO: this can be removed once the app v2.0.0 is released
+//        data object UploadedImage : Api(*Files.path)
 //    }
 //
-//    data object Communication: Api(api) {
+//    data object Communication: Api(api, "communication") {
 //        data object Courses : Api(*Communication.path, "courses")
 //        data object NotificationSettings : Api(*Communication.path, "notification-settings")
 //        data object PushNotification : Api(*Communication.path, "push_notification")
 //        data object SavedPosts : Api(*Communication.path, "saved-posts")
 //    }
 //
-//    data object Lecture: Api(api) {
+//    data object Lecture: Api(api, "lecture") {
 //        data object Lectures : Api(*Lecture.path, "lectures")
 //    }
 //
-//    data object Exercise: Api(api) {
+//    data object Exercise: Api(api, "exercise") {
 //        data object Exercises : Api(*Exercise.path, "exercises")
 //    }
 //
-//    data object Text: Api(api) {
+//    data object Text: Api(api, "text") {
 //        data object TextExercises : Api(*Text.path, "text-exercises")
 //    }
 //
-//    data object Modeling: Api(api) {
+//    data object Modeling: Api(api, "modeling") {
 //        data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
 //    }
 //
-//    data object Programming: Api(api) {
+//    data object Programming: Api(api, "programming") {
 //        data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
 //    }
 //
-//    data object Quiz: Api(api) {
+//    data object Quiz: Api(api, "quiz") {
 //        data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
 //    }
+
+
+    // Prior to 8.0.0 API changes:
+    // Uncomment this block and remove the block above to run the app with a Artemis version lower than 8.0.0
+
+    data object Core: Api(api) {
+        data object Public : Api(*Core.path, "public")
+        data object Courses : Api(*Core.path, "courses")
+        data object Files : Api(*Core.path, "files")
+
+        /**
+         * This is a special case, because for the 8.0 API the image path for eg profile picture or
+         * course icons do not contain the "api(/core)/files" part, while prior to 8.0 it did.
+         */
+        data object UploadedImage : Api("")
+    }
+
+    data object Communication: Api(api) {
+        data object Courses : Api(*Communication.path, "courses")
+        data object NotificationSettings : Api(*Communication.path, "notification-settings")
+        data object PushNotification : Api(*Communication.path, "push_notification")
+        data object SavedPosts : Api(*Communication.path, "saved-posts")
+    }
+
+    data object Lecture: Api(api) {
+        data object Lectures : Api(*Lecture.path, "lectures")
+    }
+
+    data object Exercise: Api(api) {
+        data object Exercises : Api(*Exercise.path, "exercises")
+    }
+
+    data object Text: Api(api) {
+        data object TextExercises : Api(*Text.path, "text-exercises")
+    }
+
+    data object Modeling: Api(api) {
+        data object ModelingExercises : Api(*Modeling.path, "modeling-exercises")
+    }
+
+    data object Programming: Api(api) {
+        data object ProgrammingExercises : Api(*Programming.path, "programming-exercises")
+    }
+
+    data object Quiz: Api(api) {
+        data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
+    }
 }

--- a/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/defaults/ArtemisInstances.kt
+++ b/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/defaults/ArtemisInstances.kt
@@ -12,7 +12,6 @@ object ArtemisInstances {
         type = ArtemisInstance.Type.LEGACY
     )
 
-    // TODO: search for string occurences
     val LegacyTumArtemis2 = ArtemisInstance(
         host = "artemis.cit.tum.de",
         name = R.string.artemis_instance_tum_legacy,

--- a/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/defaults/ArtemisInstances.kt
+++ b/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/defaults/ArtemisInstances.kt
@@ -6,14 +6,21 @@ import de.tum.informatics.www1.artemis.native_app.core.datastore.R
 
 object ArtemisInstances {
 
-    val LegacyTumArtemis = ArtemisInstance(
+    val LegacyTumArtemis1 = ArtemisInstance(
         host = "artemis.ase.in.tum.de",
         name = R.string.artemis_instance_tum_legacy,
         type = ArtemisInstance.Type.LEGACY
     )
 
-    val TumArtemis = ArtemisInstance(
+    // TODO: search for string occurences
+    val LegacyTumArtemis2 = ArtemisInstance(
         host = "artemis.cit.tum.de",
+        name = R.string.artemis_instance_tum_legacy,
+        type = ArtemisInstance.Type.LEGACY
+    )
+
+    val TumArtemis = ArtemisInstance(
+        host = "artemis.tum.de",
         name = R.string.artemis_instance_tum_production,
         type = ArtemisInstance.Type.PRODUCTION
     )
@@ -48,10 +55,14 @@ object ArtemisInstances {
         type = ArtemisInstance.Type.TEST
     )
 
+    val legacyTumInstances = listOf(LegacyTumArtemis1, LegacyTumArtemis2)
+    private val testInstances = listOf(TumTs0, TumTs1, TumTs2)
+
     val instances: List<ArtemisInstance> =
         (if (BuildConfig.DEBUG) {
-            listOf(TumTs0, TumTs1, TumTs2)
+            testInstances
         } else emptyList()) + listOf(TumArtemis, Kit, Codeability)
+
 
     data class ArtemisInstance(val host: String, @StringRes val name: Int, val type: Type) {
         enum class Type {

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/deeplinks/ArtemisDeeplink.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/deeplinks/ArtemisDeeplink.kt
@@ -36,6 +36,7 @@ abstract class ArtemisDeeplink {
 
     companion object {
         const val IN_APP_HOST = "artemis:/"        // Defined in intent filters in AndroidManifest.xml
-        val WEB_HOSTS = ArtemisInstances.instances.map { it.host } + ArtemisInstances.LegacyTumArtemis.host
+        val WEB_HOSTS: List<String> = (ArtemisInstances.instances + ArtemisInstances.legacyTumInstances)
+            .map { it.host }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Alternative, you can install the Android SDK as described here: https://benshapi
 
 ## Build flavors
 This project is configured to support multiple [flavor dimensions](https://developer.android.com/build/build-variants):
-- TUM or unrestricted: For TUM builds, users are forced to connect to the [TUM Artemis instance](https://artemis.cit.tum.de).
+- TUM or unrestricted: For TUM builds, users are forced to connect to the [TUM Artemis instance](https://artemis.tum.de).
 - Beta or production: In beta builds, an extra label and dialog is displayed to signal that the build may contain bugs. 
 
 ## Tests


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
We should use the new tum artemis url now

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Using new tum artemis url
- Replace legacy url on the fly if previously configured

### Steps for testing
- on develop: Login to the TUM instance
- checkout this PR: 
  - see that user is not logged out
  - see that url is now artemis.tum.de (eg in settings)
  - see that api calls still work

