### PR TITLE
`Feature`: Filter messages in chats

### DIFF
--- a/feature/course-view/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseview/MessagingScreenshots.kt
+++ b/feature/course-view/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseview/MessagingScreenshots.kt
@@ -36,6 +36,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversati
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.ConversationOverviewBody
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.overview.ConversationOverviewViewModel
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ConversationServiceStub
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisFilter
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.UserRole
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ConversationUser
@@ -216,6 +217,8 @@ fun `Metis - Conversation Channel`() {
             conversationId = sharedConversation.id,
             conversationDataState = DataState.Success(sharedConversation),
             query = "",
+            filter = MetisFilter.ALL,
+            onUpdateFilter = {},
             onUpdateQuery = {},
             onNavigateBack = {},
             onNavigateToSettings = {},

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/MetisService.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/MetisService.kt
@@ -79,7 +79,7 @@ interface MetisService {
      */
     data class StandalonePostsContext(
         val metisContext: MetisContext,
-        val filter: List<MetisFilter>,
+        val filter: MetisFilter,
         val query: String?,
         val sortingStrategy: MetisSortingStrategy = MetisSortingStrategy.DATE_DESCENDING,
         val courseWideContext: CourseWideContext? = null

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/impl/MetisServiceImpl.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/impl/MetisServiceImpl.kt
@@ -103,7 +103,7 @@ internal class MetisServiceImpl(
                 if (standalonePostsContext.query != null) {
                     parameter("searchText", standalonePostsContext.query)
                 }
-                println(standalonePostsContext.filter)
+
                 if (standalonePostsContext.courseWideContext != CourseWideContext.ANNOUNCEMENT) {
                     parameter(
                         "filterToUnresolved",

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/impl/MetisServiceImpl.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/network/impl/MetisServiceImpl.kt
@@ -103,19 +103,23 @@ internal class MetisServiceImpl(
                 if (standalonePostsContext.query != null) {
                     parameter("searchText", standalonePostsContext.query)
                 }
-
+                println(standalonePostsContext.filter)
                 if (standalonePostsContext.courseWideContext != CourseWideContext.ANNOUNCEMENT) {
                     parameter(
                         "filterToUnresolved",
-                        MetisFilter.UNRESOLVED in standalonePostsContext.filter
+                        standalonePostsContext.filter == MetisFilter.UNRESOLVED
                     )
                     parameter(
                         "filterToOwn",
-                        MetisFilter.CREATED_BY_CLIENT in standalonePostsContext.filter
+                        standalonePostsContext.filter == MetisFilter.CREATED_BY_CLIENT
                     )
                     parameter(
                         "filterToAnsweredOrReacted",
-                        MetisFilter.WITH_REACTION in standalonePostsContext.filter
+                         standalonePostsContext.filter == MetisFilter.WITH_REACTION
+                    )
+                    parameter(
+                        "pinnedOnly",
+                        standalonePostsContext.filter == MetisFilter.PINNED
                     )
                 }
 
@@ -141,7 +145,7 @@ internal class MetisServiceImpl(
         val posts = getPosts(
             standalonePostsContext = MetisService.StandalonePostsContext(
                 metisContext = metisContext,
-                filter = emptyList(),
+                filter = MetisFilter.ALL,
                 query = "#$serverSidePostId",
                 sortingStrategy = MetisSortingStrategy.DATE_DESCENDING,
                 courseWideContext = null

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.DropdownMenu
@@ -263,7 +264,7 @@ fun ConversationChatListScreen(
                             }
                         ) {
                             Icon(
-                                imageVector = Icons.Outlined.Info,
+                                imageVector = Icons.Default.MoreVert,
                                 tint = MaterialTheme.colorScheme.primary,
                                 contentDescription = null
                             )
@@ -439,31 +440,31 @@ fun FilterDropdownMenu(
         onDismissRequest = onDismissRequest
     ) {
         DropdownMenuItem(
-            leadingIcon = if (filter == MetisFilter.ALL) icon else null,
+            trailingIcon = if (filter == MetisFilter.ALL) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_all)) },
             onClick = { onFilterSelected(MetisFilter.ALL) }
         )
 
         DropdownMenuItem(
-            leadingIcon = if (filter == MetisFilter.UNRESOLVED) icon else null,
+            trailingIcon = if (filter == MetisFilter.UNRESOLVED) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_unresolved)) },
             onClick = { onFilterSelected(MetisFilter.UNRESOLVED) }
         )
 
         DropdownMenuItem(
-            leadingIcon = if (filter == MetisFilter.CREATED_BY_CLIENT) icon else null,
+            trailingIcon = if (filter == MetisFilter.CREATED_BY_CLIENT) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_own)) },
             onClick = { onFilterSelected(MetisFilter.CREATED_BY_CLIENT) }
         )
 
         DropdownMenuItem(
-            leadingIcon = if (filter == MetisFilter.WITH_REACTION) icon else null,
+            trailingIcon = if (filter == MetisFilter.WITH_REACTION) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_reacted)) },
             onClick = { onFilterSelected(MetisFilter.WITH_REACTION) }
         )
 
         DropdownMenuItem(
-            leadingIcon = if (filter == MetisFilter.PINNED) icon else null,
+            trailingIcon = if (filter == MetisFilter.PINNED) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_pinned)) },
             onClick = { onFilterSelected(MetisFilter.PINNED) }
         )

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationChatListScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Search
@@ -68,6 +69,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.reply.autocomplete.LocalReplyAutoCompleteHintProvider
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.shared.ConversationDataStatusButton
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.shared.isReplyEnabled
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisFilter
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.StandalonePostId
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.Conversation
@@ -130,8 +132,10 @@ internal fun ConversationChatListScreen(
         conversationDataState = conversationDataState,
         conversationDataStatus = conversationDataStatus,
         query = query,
+        filter = filter,
         onNavigateBack = onNavigateBack,
         onNavigateToSettings = onNavigateToSettings,
+        onUpdateFilter = viewModel.chatListUseCase::updateFilter,
         onUpdateQuery = viewModel.chatListUseCase::updateQuery,
         onRequestSoftReload = viewModel::requestReload
     ) { padding ->
@@ -162,11 +166,13 @@ fun ConversationChatListScreen(
     courseId: Long,
     conversationId: Long,
     query: String,
+    filter: MetisFilter,
     conversationDataStatus: DataStatus,
     conversationDataState: DataState<Conversation>,
     onNavigateBack: () -> Unit,
     onNavigateToSettings: () -> Unit,
     onUpdateQuery: (String) -> Unit,
+    onUpdateFilter: (MetisFilter) -> Unit,
     onRequestSoftReload: () -> Unit,
     content: @Composable (PaddingValues) -> Unit
 ) {
@@ -275,6 +281,8 @@ fun ConversationChatListScreen(
 
                             FilterDropdownMenu(
                                 isFilterDropdownExpanded = isFilterDropdownExpanded,
+                                filter = filter,
+                                onFilterSelected = onUpdateFilter,
                                 onDismissRequest = { isFilterDropdownExpanded = false }
                             )
                         }
@@ -415,70 +423,49 @@ private fun InfoDropdownMenu(
 @Composable
 fun FilterDropdownMenu(
     isFilterDropdownExpanded: Boolean,
+    filter: MetisFilter,
     onDismissRequest: () -> Unit,
+    onFilterSelected: (MetisFilter) -> Unit
 ) {
+    val icon = @Composable {
+        Icon(
+            imageVector = Icons.Default.Check,
+            contentDescription = null
+        )
+    }
+
     DropdownMenu(
         expanded = isFilterDropdownExpanded,
         onDismissRequest = onDismissRequest
     ) {
         DropdownMenuItem(
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.open),
-                    contentDescription = null
-                )
-            },
+            leadingIcon = if (filter == MetisFilter.ALL) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_all)) },
-            onClick = {
-            }
+            onClick = { onFilterSelected(MetisFilter.ALL) }
         )
 
         DropdownMenuItem(
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.open),
-                    contentDescription = null
-                )
-            },
+            leadingIcon = if (filter == MetisFilter.UNRESOLVED) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_unresolved)) },
-            onClick = {
-            }
+            onClick = { onFilterSelected(MetisFilter.UNRESOLVED) }
         )
 
         DropdownMenuItem(
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.open),
-                    contentDescription = null
-                )
-            },
+            leadingIcon = if (filter == MetisFilter.CREATED_BY_CLIENT) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_own)) },
-            onClick = {
-            }
+            onClick = { onFilterSelected(MetisFilter.CREATED_BY_CLIENT) }
         )
 
         DropdownMenuItem(
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.open),
-                    contentDescription = null
-                )
-            },
+            leadingIcon = if (filter == MetisFilter.WITH_REACTION) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_reacted)) },
-            onClick = {
-            }
+            onClick = { onFilterSelected(MetisFilter.WITH_REACTION) }
         )
 
         DropdownMenuItem(
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.open),
-                    contentDescription = null
-                )
-            },
+            leadingIcon = if (filter == MetisFilter.PINNED) icon else null,
             text = { Text(text = stringResource(R.string.conversation_filter_messages_pinned)) },
-            onClick = {
-            }
+            onClick = { onFilterSelected(MetisFilter.PINNED) }
         )
     }
 }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/ConversationViewModel.kt
@@ -842,5 +842,4 @@ internal open class ConversationViewModel(
             cursor.getString(nameIndex)
         } ?: uri.lastPathSegment.orEmpty()
     }
-
 }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/ConversationChatListUseCase.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/ConversationChatListUseCase.kt
@@ -87,7 +87,6 @@ class ConversationChatListUseCase(
         _filter,
         delayedQuery
     ) { filter, query ->
-        println(filter)
         StandalonePostsContext(
             metisContext = metisContext,
             filter = filter,
@@ -131,7 +130,6 @@ class ConversationChatListUseCase(
     @OptIn(ExperimentalPagingApi::class)
     val postPagingData: Flow<PagingData<ChatListItem>> =
         pagingDataInput.flatMapLatest { pagingDataInput ->
-            println(pagingDataInput.standalonePostsContext.filter)
             val config = PagingConfig(
                 pageSize = PAGE_SIZE,
                 enablePlaceholders = true

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/ConversationChatListUseCase.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/ConversationChatListUseCase.kt
@@ -71,8 +71,8 @@ class ConversationChatListUseCase(
         private const val PAGE_SIZE = 20
     }
 
-    private val _filter = MutableStateFlow<List<MetisFilter>>(emptyList())
-    val filter: StateFlow<List<MetisFilter>> = _filter
+    private val _filter = MutableStateFlow(MetisFilter.ALL)
+    val filter: StateFlow<MetisFilter> = _filter
 
     private val _query = MutableStateFlow<String?>(null)
     val query: StateFlow<String> = _query
@@ -87,6 +87,7 @@ class ConversationChatListUseCase(
         _filter,
         delayedQuery
     ) { filter, query ->
+        println(filter)
         StandalonePostsContext(
             metisContext = metisContext,
             filter = filter,
@@ -130,6 +131,7 @@ class ConversationChatListUseCase(
     @OptIn(ExperimentalPagingApi::class)
     val postPagingData: Flow<PagingData<ChatListItem>> =
         pagingDataInput.flatMapLatest { pagingDataInput ->
+            println(pagingDataInput.standalonePostsContext.filter)
             val config = PagingConfig(
                 pageSize = PAGE_SIZE,
                 enablePlaceholders = true
@@ -142,7 +144,8 @@ class ConversationChatListUseCase(
             )
 
             val isSearchActive = !pagingDataInput.standalonePostsContext.query.isNullOrBlank()
-            val pagerFlow = if (!isSearchActive) {
+            val isFilteringActive = pagingDataInput.standalonePostsContext.filter != MetisFilter.ALL
+            val pagerFlow = if (!isSearchActive && !isFilteringActive) {
                 Pager(
                     config = config,
                     remoteMediator = MetisRemoteMediator(
@@ -332,6 +335,10 @@ class ConversationChatListUseCase(
 
     fun updateQuery(new: String) {
         _query.value = new.ifEmpty { null }
+    }
+
+    fun updateFilter(new: MetisFilter) {
+        _filter.value = new
     }
 
     private fun insertDateSeparators(pagingList: PagingData<ChatListItem.PostItem.IndexedItem>) =

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisRemoteMediator.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisRemoteMediator.kt
@@ -3,7 +3,9 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 import android.util.Log
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.LoadType
-import androidx.paging.LoadType.*
+import androidx.paging.LoadType.APPEND
+import androidx.paging.LoadType.PREPEND
+import androidx.paging.LoadType.REFRESH
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import de.tum.informatics.www1.artemis.native_app.core.data.NetworkResponse
@@ -11,6 +13,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ser
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisService.StandalonePostsContext
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.storage.MetisStorageService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisFilter
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisSortingStrategy
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.StandalonePost
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.db.pojo.PostPojo
@@ -95,7 +98,7 @@ internal class MetisRemoteMediator(
             return metisService.getPosts(
                 standalonePostsContext = StandalonePostsContext(
                     metisContext = context,
-                    filter = emptyList(),
+                    filter = MetisFilter.ALL,
                     query = null,
                     sortingStrategy = MetisSortingStrategy.DATE_DESCENDING,
                     courseWideContext = null

--- a/feature/metis/conversation/src/main/res/values/conversation_strings.xml
+++ b/feature/metis/conversation/src/main/res/values/conversation_strings.xml
@@ -15,6 +15,12 @@
     <string name="conversation_details_title">Details</string>
     <string name="conversation_go_to_exercise">Go to exercise</string>
     <string name="conversation_go_to_lecture">Go to lecture</string>
+    <string name="conversation_filter_messages">Filter Messages</string>
+    <string name="conversation_filter_messages_all">All</string>
+    <string name="conversation_filter_messages_own">Own</string>
+    <string name="conversation_filter_messages_unresolved">Unresolved</string>
+    <string name="conversation_filter_messages_reacted">Reacted</string>
+    <string name="conversation_filter_messages_pinned">Pinned</string>
 
     <string name="course_wide_context_organization">Organization</string>
     <string name="course_wide_context_tech_support">Tech Support</string>

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ConversationMessagesE2eTest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ConversationMessagesE2eTest.kt
@@ -8,6 +8,7 @@ import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.DefaultTi
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisModificationService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.network.MetisService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.post.post_actions.predefinedEmojiIds
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisFilter
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisSortingStrategy
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.DisplayPriority
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.StandalonePost
@@ -47,7 +48,7 @@ class ConversationMessagesE2eTest : ConversationMessagesBaseTest() {
             val downloadedPosts = metisService.getPosts(
                 MetisService.StandalonePostsContext(
                     metisContext,
-                    emptyList(),
+                    MetisFilter.ALL,
                     "",
                     MetisSortingStrategy.DATE_ASCENDING,
                     null
@@ -84,7 +85,7 @@ class ConversationMessagesE2eTest : ConversationMessagesBaseTest() {
                 metisService.getPosts(
                     MetisService.StandalonePostsContext(
                         metisContext,
-                        emptyList(),
+                        MetisFilter.ALL,
                         null,
                         MetisSortingStrategy.DATE_DESCENDING,
                         null

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/MetisFilter.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/MetisFilter.kt
@@ -2,6 +2,10 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content
 
 enum class MetisFilter {
     /**
+     * Disabled filter.
+     */
+    ALL,
+    /**
      * Filter for the courses this user has created.
      */
     CREATED_BY_CLIENT,
@@ -12,5 +16,9 @@ enum class MetisFilter {
     /**
      * Filter for posts which have not been resolved yet
      */
-    UNRESOLVED
+    UNRESOLVED,
+    /**
+     * Filter for posts which are pinned
+     */
+    PINNED
 }


### PR DESCRIPTION
### Problem Description

Currently, there is no filtering for messages available as in the iOS app.

### Changes

This PR adds a filtering option to the dropdown menu in conversations and adds filtering logic. 
Filtering is available for own, reacted, pinned and unresolved messages.

### Steps for testing

1. Go into any channel
2. Click the more icon in the top bar
3. Click on Filter Messages
4. Verify the filtering dropdown menu is shown 
5. Click on the options and verify the correct messages are shown.

### Screenshots
<img src="https://github.com/user-attachments/assets/3845f8f1-831b-4536-82d9-584b442ebcd7" data-canonical-src="https://github.com/user-attachments/assets/3845f8f1-831b-4536-82d9-584b442ebcd7" height="700"/>