### PR TITLE
`Chore`: Use new file upload URL for FAQs

### DIFF
--- a/feature/faq/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/faq/ui/FaqArtemisMarkdownTransformer.kt
+++ b/feature/faq/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/faq/ui/FaqArtemisMarkdownTransformer.kt
@@ -3,7 +3,6 @@ package de.tum.informatics.www1.artemis.native_app.feature.faq.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import de.tum.informatics.www1.artemis.native_app.core.common.markdown.ArtemisMarkdownTransformer
-import de.tum.informatics.www1.artemis.native_app.core.data.service.Api
 import io.ktor.http.URLBuilder
 import io.ktor.http.appendPathSegments
 
@@ -27,10 +26,8 @@ class FaqArtemisMarkdownTransformer(
         filePath: String
     ): String {
         val url = URLBuilder(serverUrl).apply {
-            appendPathSegments(*Api.Core.UploadedFile.path)
             appendPathSegments(filePath)
         }.buildString()
-        println("File upload message markdown: $url")
         val link = "[$fileName]($url)"
         return if (isImage) "!$link" else link
     }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
There was a bug in the file upload API that required changes to the returned path URL after a file upload. As the Android FAQ  implementation assumed that was a feature and not a bug, we need to undo these URL adjustments.

This closes #526 

### Steps for testing
Test with a server that has  https://github.com/ls1intum/Artemis/pull/10622 merged (eg the develop branch). You can deploy the develop branch with Helios.

- Webapp: Create a new FAQ with an image (or use TS2 > Test Course Martin Felber)
- Navigate to the FAQ in the Android app
- Verify that you can see the image in the FAQ details page
