### PR TITLE
`Feature`: Toggle Channel Privacy

### DIFF
--- a/feature/login-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/test/TestLoginUtil.kt
+++ b/feature/login-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/test/TestLoginUtil.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.test.KoinTest
 import org.koin.test.get
 
-val user1Username: String get() = System.getenv("USER_1_USERNAME") ?: "aa01aaa"
-val user1Password: String get() = System.getenv("USER_1_PASSWORD") ?: "test_user_1_password"
+val user1Username: String get() = System.getenv("USER_1_USERNAME") ?: "artemis_admin"
+val user1Password: String get() = System.getenv("USER_1_PASSWORD") ?: "artemis_admin"
 val user1DisplayName: String get() = System.getenv("USER_1_DISPLAY_NAME") ?: "Test User1"
 
 val user2Username: String get() = System.getenv("USER_2_USERNAME") ?: "aa02aaa"

--- a/feature/login-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/test/TestLoginUtil.kt
+++ b/feature/login-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/test/TestLoginUtil.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.test.KoinTest
 import org.koin.test.get
 
-val user1Username: String get() = System.getenv("USER_1_USERNAME") ?: "artemis_admin"
-val user1Password: String get() = System.getenv("USER_1_PASSWORD") ?: "artemis_admin"
+val user1Username: String get() = System.getenv("USER_1_USERNAME") ?: "aa01aaa"
+val user1Password: String get() = System.getenv("USER_1_PASSWORD") ?: "test_user_1_password"
 val user1DisplayName: String get() = System.getenv("USER_1_DISPLAY_NAME") ?: "Test User1"
 
 val user2Username: String get() = System.getenv("USER_2_USERNAME") ?: "aa02aaa"

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/overview/ConversationOtherSettings.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/overview/ConversationOtherSettings.kt
@@ -28,10 +28,12 @@ internal fun ConversationOtherSettings(
     conversation: Conversation,
     onLeaveConversation: () -> Unit,
     onToggleChannelArchivation: () -> Unit,
+    onToggleChannelPrivacy: () -> Unit,
     onDeleteChannel: () -> Unit
 ) {
     var displayArchiveChannelDialog by remember { mutableStateOf(false) }
     var displayDeleteChannelDialog by remember { mutableStateOf(false) }
+    var displayChannelPrivacyDialog by remember { mutableStateOf(false) }
 
     val buttonModifier = Modifier.fillMaxWidth()
 
@@ -62,8 +64,24 @@ internal fun ConversationOtherSettings(
 
             val canDeleteChannels = !isTutorialGroupChannel && hasChannelModerationRights && isChannelModerator && isCreator
 
-            // Archive/Unarchive and Delete Buttons
+            // Archive/Unarchive, Delete and Toggle Channel Privacy Buttons
             if (hasChannelModerationRights) {
+                OutlinedButton(
+                    modifier = buttonModifier,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                    onClick = { displayChannelPrivacyDialog = true }
+                ) {
+                    Text(
+                        text = stringResource(
+                            id = if (conversation.isPublic) {
+                                R.string.conversation_settings_section_channel_toggle_privacy_private
+                            } else {
+                                R.string.conversation_settings_section_channel_toggle_privacy_public
+                            }
+                        )
+                    )
+                }
+
                 OutlinedButton(
                     modifier = buttonModifier,
                     border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
@@ -116,6 +134,18 @@ internal fun ConversationOtherSettings(
             onDismiss = { displayDeleteChannelDialog = false }
         )
     }
+
+    if (displayChannelPrivacyDialog && conversation is ChannelChat) {
+        ChannelPrivacyToggleDialog(
+            conversation = conversation,
+            onToggleChannelPrivacy = {
+                displayChannelPrivacyDialog = false
+                onToggleChannelPrivacy()
+            },
+            onDismiss = { displayChannelPrivacyDialog = false }
+        )
+    }
+
 }
 
 @Composable
@@ -175,6 +205,42 @@ private fun ArchiveChannelDialog(
         confirmButtonText = stringResource(id = confirmRes),
         dismissButtonText = stringResource(id = dismissRes),
         onPressPositiveButton = onToggleChannelArchivation,
+        onDismissRequest = onDismiss
+    )
+}
+
+@Composable
+private fun ChannelPrivacyToggleDialog(
+    conversation: ChannelChat,
+    onToggleChannelPrivacy: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val makePublic = !conversation.isPublic
+
+    val titleRes = if (makePublic) {
+        R.string.conversation_settings_section_channel_toggle_privacy_title_public
+    } else {
+        R.string.conversation_settings_section_channel_toggle_privacy_title_private
+    }
+
+    val messageRes = if (makePublic) {
+        R.string.conversation_settings_section_channel_toggle_privacy_message_public
+    } else {
+        R.string.conversation_settings_section_channel_toggle_privacy_message_private
+    }
+
+    val confirmRes = if (makePublic) {
+        R.string.conversation_settings_section_channel_toggle_privacy_public_button
+    } else {
+        R.string.conversation_settings_section_channel_toggle_privacy_private_button
+    }
+
+    MarkdownTextAlertDialog(
+        title = stringResource(id = titleRes),
+        text = stringResource(id = messageRes),
+        confirmButtonText = stringResource(id = confirmRes),
+        dismissButtonText = stringResource(id = R.string.conversation_settings_section_channel_toggle_privacy_negative),
+        onPressPositiveButton = onToggleChannelPrivacy,
         onDismissRequest = onDismiss
     )
 }

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/overview/ConversationSettingsBody.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/overview/ConversationSettingsBody.kt
@@ -65,6 +65,7 @@ internal fun ConversationSettingsBody(
     var leaveConversationJob: Deferred<Boolean>? by remember { mutableStateOf(null) }
     var archiveChannelJob: Deferred<Boolean>? by remember { mutableStateOf(null) }
     var deleteChannelJob: Deferred<Boolean>? by remember { mutableStateOf(null) }
+    var togglePrivacyJob: Deferred<Boolean>? by remember { mutableStateOf(null) }
 
     var displaySaveFailedDialog by remember { mutableStateOf(false) }
 
@@ -115,6 +116,15 @@ internal fun ConversationSettingsBody(
             if (successful) {
                 onChannelDeleted()
             }
+        }
+    )
+
+    AwaitDeferredCompletion(
+        job = togglePrivacyJob,
+        onComplete = { successful ->
+            togglePrivacyJob = null
+
+            onSaveResult(successful)
         }
     )
 
@@ -201,6 +211,9 @@ internal fun ConversationSettingsBody(
                 },
                 onDeleteChannel = {
                     deleteChannelJob = viewModel.deleteConversation()
+                },
+                onToggleChannelPrivacy = {
+                    togglePrivacyJob = viewModel.toggleChannelPrivacy()
                 }
             )
         }

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/overview/ConversationSettingsViewModel.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/overview/ConversationSettingsViewModel.kt
@@ -386,4 +386,25 @@ internal class ConversationSettingsViewModel(
             result
         }
     }
+
+    fun toggleChannelPrivacy(): Deferred<Boolean> {
+        return viewModelScope.async(coroutineContext) {
+            val result = conversationService.toggleChannelPrivacy(
+                courseId = conversationSettings.value.courseId,
+                conversationId = conversationSettings.value.conversationId,
+                authToken = accountService.authToken.first(),
+                serverUrl = serverConfigurationService.serverUrl.first()
+            ).onFailure {
+                    Log.d(TAG, "Failed to toggle channel privacy", it)
+                }.or(false)
+
+            if (result) {
+                onRequestReload.tryEmit(Unit)
+            }
+
+            result
+        }
+    }
+
+
 }

--- a/feature/metis/manage-conversations/src/main/res/values/conversation_settings_strings.xml
+++ b/feature/metis/manage-conversations/src/main/res/values/conversation_settings_strings.xml
@@ -74,4 +74,15 @@
     <string name="conversation_settings_section_delete_channel_title">Delete channel?</string>
     <string name="conversation_settings_section_delete_channel_message">**Are you sure to delete the channel %1$s?** This is a permanent action and cannot be undone.</string>
     <string name="conversation_settings_section_delete_channel_negative">@android:string/cancel</string>
+
+    <string name="conversation_settings_section_channel_toggle_privacy_title_public">Change to a public channel?</string>
+    <string name="conversation_settings_section_channel_toggle_privacy_title_private">Change to a private channel?</string>
+    <string name="conversation_settings_section_channel_toggle_privacy_message_public">**Do you really want to change this channel to public?**\n\nKeep in mind that making a channel public allows anyone in the course to join, and new members will be able to see past messages.</string>
+    <string name="conversation_settings_section_channel_toggle_privacy_message_private">**Are you sure you want to make this channel private?**\n\nOnly users with moderation rights will be able to add new members.</string>
+    <string name="conversation_settings_section_channel_toggle_privacy_public">Change to public channel</string>
+    <string name="conversation_settings_section_channel_toggle_privacy_private">Change to private channel</string>
+    <string name="conversation_settings_section_channel_toggle_privacy_public_button">Change to public</string>
+    <string name="conversation_settings_section_channel_toggle_privacy_private_button">Change to private</string>
+    <string name="conversation_settings_section_channel_toggle_privacy_negative">@android:string/cancel</string>
+
 </resources>

--- a/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/settings/ChannelSettingsE2eTest.kt
+++ b/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/settings/ChannelSettingsE2eTest.kt
@@ -211,4 +211,25 @@ internal class ChannelSettingsE2eTest : ConversationSettingsBaseE2eTest() {
 
         composeTestRule.waitUntil(DefaultTimeoutMillis) { channelDeleted }
     }
+
+    @Test(timeout = DefaultTestTimeoutMillis)
+    fun `can toggle channel privacy`() {
+        val channel = runBlockingWithTestTimeout {
+            conversationService.createChannel(
+                courseId = course.id!!,
+                name = "toggleprivacychannel",
+                description = "privacy test",
+                isPublic = true,
+                isAnnouncement = false,
+                isCourseWide = false,
+                authToken = accessToken,
+                serverUrl = testServerUrl
+            ).orThrow("Could not create channel")
+        }
+
+        setupUiAndViewModel(channel)
+
+        toggleChannelPrivacyTestImpl(channel)
+
+    }
 }

--- a/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/settings/ConversationSettingsBaseE2eTest.kt
+++ b/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/settings/ConversationSettingsBaseE2eTest.kt
@@ -19,6 +19,7 @@ import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.DefaultTi
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.settings.overview.ConversationSettingsScreen
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.settings.overview.ConversationSettingsViewModel
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.Conversation
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.service.network.getConversation
 import de.tum.informatics.www1.artemis.native_app.feature.metistest.ConversationBaseTest
@@ -182,6 +183,60 @@ internal abstract class ConversationSettingsBaseE2eTest : ConversationBaseTest()
             )
             .assertExists()
             .performClick()
+    }
+
+    protected fun toggleChannelPrivacyTestImpl(conversation: Conversation) {
+        val isPublic = (conversation as ChannelChat).isPublic
+        val toggleButtonText = context.getString(
+            if (isPublic)
+                R.string.conversation_settings_section_channel_toggle_privacy_private
+            else
+                R.string.conversation_settings_section_channel_toggle_privacy_public
+        )
+
+        val expectedTitle = context.getString(
+            if (isPublic)
+                R.string.conversation_settings_section_channel_toggle_privacy_title_private
+            else
+                R.string.conversation_settings_section_channel_toggle_privacy_title_public
+        )
+
+        val expectedButton = context.getString(
+            if (isPublic)
+                R.string.conversation_settings_section_channel_toggle_privacy_private_button
+            else
+                R.string.conversation_settings_section_channel_toggle_privacy_public_button
+        )
+
+        composeTestRule.waitUntilAtLeastOneExists(
+            hasText(toggleButtonText),
+            DefaultTimeoutMillis
+        )
+
+        composeTestRule
+            .onNodeWithText(toggleButtonText)
+            .performScrollTo()
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule
+            .onNode(
+                hasAnyAncestor(isDialog()) and hasText(expectedTitle)
+            )
+            .assertExists()
+
+        composeTestRule
+            .onNode(
+                hasAnyAncestor(isDialog()) and hasText(expectedButton)
+            )
+            .assertExists()
+            .performClick()
+
+        composeTestRule
+            .waitUntilExactlyOneExists(
+                hasText(toggleButtonText),
+                DefaultTimeoutMillis
+            )
     }
 
 }

--- a/feature/metis/shared/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ConversationServiceStub.kt
+++ b/feature/metis/shared/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ConversationServiceStub.kt
@@ -182,5 +182,12 @@ open class ConversationServiceStub(
         conversationId: Long,
         authToken: String,
         serverUrl: String
-    ): NetworkResponse<Boolean> =  NetworkResponse.Failure(StubException)
+    ): NetworkResponse<Boolean> = NetworkResponse.Failure(StubException)
+
+    override suspend fun toggleChannelPrivacy(
+        courseId: Long,
+        conversationId: Long,
+        authToken: String,
+        serverUrl: String
+    ): NetworkResponse<Boolean> = NetworkResponse.Failure(StubException)
 }

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/ConversationService.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/ConversationService.kt
@@ -190,6 +190,13 @@ interface ConversationService {
         authToken: String,
         serverUrl: String
     ): NetworkResponse<Boolean>
+
+    suspend fun toggleChannelPrivacy(
+        courseId: Long,
+        conversationId: Long,
+        authToken: String,
+        serverUrl: String
+    ): NetworkResponse<Boolean>
 }
 
 suspend fun ConversationService.getConversation(

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
@@ -588,4 +588,28 @@ class ConversationServiceImpl(private val ktorProvider: KtorProvider) : Conversa
             }.status.isSuccess()
         }
     }
+
+    override suspend fun toggleChannelPrivacy(
+        courseId: Long,
+        conversationId: Long,
+        authToken: String,
+        serverUrl: String
+    ): NetworkResponse<Boolean> {
+        return performNetworkCall {
+            ktorProvider.ktorClient.post(serverUrl) {
+                url {
+                    appendPathSegments(
+                        *Api.Communication.Courses.path,
+                        courseId.toString(),
+                        "channels",
+                        conversationId.toString(),
+                        "toggle-privacy"
+                    )
+                }
+                cookieAuth(authToken)
+                contentType(ContentType.Application.Json)
+            }.status.isSuccess()
+        }
+    }
+
 }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
Android app currently lacks the ability to toggle channel privacy,  currently web app have this function.. Adding this option enables users to seamlessly switch between public and private channels, improving flexibility and access control.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
The ability to toggle channel privacy has been added. This feature is integrated into the Channel Settings.
 It allows switching a public channel to private and vice versa. I
 nformative confirmation dialogs have also been implemented.

### Steps for testing
1 user with moderation rights

Open course activated Channel 
- Create a new public channel (or use existing one )  and from channel setting toggle the privacy
- Create a new private channel (or use existing one ) and from channel setting toggle the privacy

In each case should display a pop up to inform user about the changes that will be made. (See Screenshot)
And verify the privacy is toggled from public to private or vice versa


### Screenshots

![Screenshot 2025-04-03 at 22 16 28](https://github.com/user-attachments/assets/c00c8be5-ca8a-4994-aad5-41c8fb6d5966)
![Screenshot 2025-04-03 at 22 16 35](https://github.com/user-attachments/assets/4c5c5466-aca8-47bd-bc9a-61409682a84c)

