### PR TITLE
`Chore`: Combine `ConversationAddMembersScreen` and `CreatePersonalConversationScreen`

### DIFF
--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/common/ConversationUserSelectionScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/common/ConversationUserSelectionScreen.kt
@@ -1,0 +1,117 @@
+package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
+import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
+import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.ArtemisTopAppBar
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.JobAnimatedFloatingActionButton
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.NavigationBackButton
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.MemberSelection
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.MemberSelectionBaseViewModel
+import kotlinx.coroutines.Deferred
+
+@Composable
+internal fun <T> ConversationUserSelectionScreen(
+    modifier: Modifier = Modifier,
+    viewModel: MemberSelectionBaseViewModel,
+    displayFailedDialog: Boolean,
+    titleRes: Int,
+    dialogTitleRes: Int,
+    dialogMessageRes: Int,
+    dialogConfirmTextRes: Int,
+    fabTestTag: String,
+    fabIcon: ImageVector,
+    canSubmit: Boolean,
+    startJob: () -> Deferred<T?>,
+    onJobCompleted: (T?) -> Unit,
+    onNavigateBack: () -> Unit,
+    onDismissFailedDialog: () -> Unit
+) {
+    var numberOfSelectedUsers by remember { mutableIntStateOf(0) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            ArtemisTopAppBar(
+                title = { Text(stringResource(id = titleRes)) },
+                navigationIcon = {
+                    NavigationBackButton(onNavigateBack = onNavigateBack)
+                }
+            )
+        },
+        floatingActionButton = {
+            JobAnimatedFloatingActionButton(
+                modifier = Modifier
+                    .imePadding()
+                    .testTag(fabTestTag),
+                enabled = canSubmit,
+                startJob = startJob,
+                onJobCompleted = onJobCompleted
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        pluralStringResource(
+                            R.plurals.create_personal_conversation_members,
+                            numberOfSelectedUsers,
+                            numberOfSelectedUsers
+                        )
+                    )
+                    Icon(
+                        modifier = Modifier
+                            .padding(start = 8.dp),
+                        imageVector = fabIcon,
+                        contentDescription = null
+                    )
+                }
+            }
+        }
+    ) { padding ->
+        MemberSelection(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = padding.calculateTopPadding() + Spacings.ScreenTopBarSpacing)
+                .padding(horizontal = Spacings.ScreenHorizontalSpacing)
+                .consumeWindowInsets(WindowInsets.systemBars.only(WindowInsetsSides.Top)),
+            viewModel = viewModel,
+            onUpdateSelectedUserCount = { numberOfSelectedUsers = it }
+        )
+    }
+
+    if (displayFailedDialog) {
+        TextAlertDialog(
+            title = stringResource(dialogTitleRes),
+            text = stringResource(dialogMessageRes),
+            confirmButtonText = stringResource(dialogConfirmTextRes),
+            dismissButtonText = null,
+            onPressPositiveButton = onDismissFailedDialog,
+            onDismissRequest = onDismissFailedDialog
+        )
+    }
+}

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/common/ConversationUserSelectionScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/common/ConversationUserSelectionScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -39,12 +41,12 @@ internal fun <T> ConversationUserSelectionScreen(
     modifier: Modifier = Modifier,
     viewModel: MemberSelectionBaseViewModel,
     displayFailedDialog: Boolean,
-    titleRes: Int,
-    dialogTitleRes: Int,
-    dialogMessageRes: Int,
-    dialogConfirmTextRes: Int,
+    titleRes: Int = R.string.create_personal_conversation_title,
+    dialogTitleRes: Int = R.string.create_personal_conversation_failed_title,
+    dialogMessageRes: Int = R.string.create_personal_conversation_failed_message,
+    dialogConfirmTextRes: Int = R.string.create_personal_conversation_failed_positive,
     fabTestTag: String,
-    fabIcon: ImageVector,
+    fabIcon: ImageVector = Icons.Default.ChevronRight,
     canSubmit: Boolean,
     startJob: () -> Deferred<T?>,
     onJobCompleted: (T?) -> Unit,

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/common/PotentiallyIllegalTextField.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/common/PotentiallyIllegalTextField.kt
@@ -1,4 +1,4 @@
-package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation
+package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common
 
 import androidx.annotation.StringRes
 import androidx.compose.material3.MaterialTheme

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/create_channel/CreateChannelScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/create_channel/CreateChannelScreen.kt
@@ -49,7 +49,7 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.Art
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.NavigationBackButton
 import de.tum.informatics.www1.artemis.native_app.core.ui.pagePadding
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
-import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.PotentiallyIllegalTextField
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common.PotentiallyIllegalTextField
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/create_personal_conversation/CreatePersonalConversationScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/create_personal_conversation/CreatePersonalConversationScreen.kt
@@ -1,7 +1,5 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_personal_conversation
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -9,7 +7,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common.ConversationUserSelectionScreen
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -31,12 +28,7 @@ fun CreatePersonalConversationScreen(
         modifier = modifier,
         viewModel = viewModel,
         displayFailedDialog = displayFailedDialog,
-        titleRes = R.string.create_personal_conversation_title,
-        dialogTitleRes = R.string.create_personal_conversation_failed_title,
-        dialogMessageRes = R.string.create_personal_conversation_failed_message,
-        dialogConfirmTextRes = R.string.create_personal_conversation_failed_positive,
         fabTestTag = TEST_TAG_CREATE_PERSONAL_CONVERSATION_BUTTON,
-        fabIcon = Icons.Default.ChevronRight,
         canSubmit = canCreateConversation,
         startJob = viewModel::createConversation,
         onJobCompleted = { conversation ->

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/create_personal_conversation/CreatePersonalConversationScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/create_personal_conversation/CreatePersonalConversationScreen.kt
@@ -1,39 +1,16 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_personal_conversation
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
-import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
-import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.ArtemisTopAppBar
-import de.tum.informatics.www1.artemis.native_app.core.ui.compose.JobAnimatedFloatingActionButton
-import de.tum.informatics.www1.artemis.native_app.core.ui.compose.NavigationBackButton
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.MemberSelection
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common.ConversationUserSelectionScreen
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -46,80 +23,30 @@ fun CreatePersonalConversationScreen(
     onConversationCreated: (conversationId: Long) -> Unit,
     onNavigateBack: () -> Unit
 ) {
-    CreatePersonalConversationScreen(
+    val viewModel = koinViewModel<CreatePersonalConversationViewModel> { parametersOf(courseId) }
+    val canCreateConversation by viewModel.canCreateConversation.collectAsState()
+    var displayFailedDialog by remember { mutableStateOf(false) }
+
+    ConversationUserSelectionScreen(
         modifier = modifier,
-        viewModel = koinViewModel { parametersOf(courseId) },
-        onConversationCreated = onConversationCreated,
+        viewModel = viewModel,
+        displayFailedDialog = displayFailedDialog,
+        titleRes = R.string.create_personal_conversation_title,
+        dialogTitleRes = R.string.create_personal_conversation_failed_title,
+        dialogMessageRes = R.string.create_personal_conversation_failed_message,
+        dialogConfirmTextRes = R.string.create_personal_conversation_failed_positive,
+        fabTestTag = TEST_TAG_CREATE_PERSONAL_CONVERSATION_BUTTON,
+        fabIcon = Icons.Default.ChevronRight,
+        canSubmit = canCreateConversation,
+        startJob = viewModel::createConversation,
+        onJobCompleted = { conversation ->
+            if (conversation != null) {
+                onConversationCreated(conversation.id)
+            } else {
+                displayFailedDialog = true
+            }
+        },
+        onDismissFailedDialog = { displayFailedDialog = false },
         onNavigateBack = onNavigateBack
     )
-}
-
-@Composable
-internal fun CreatePersonalConversationScreen(
-    modifier: Modifier,
-    viewModel: CreatePersonalConversationViewModel,
-    onConversationCreated: (conversationId: Long) -> Unit,
-    onNavigateBack: () -> Unit
-) {
-    val canCreateConversation by viewModel.canCreateConversation.collectAsState()
-
-    var displayCreateConversationFailedDialog: Boolean by remember { mutableStateOf(false) }
-    var numberOfSelectedUsers by remember { mutableIntStateOf(0) }
-
-    Scaffold(
-        modifier = modifier,
-        topBar = {
-            ArtemisTopAppBar(
-                title = { Text(text = stringResource(id = R.string.create_personal_conversation_title)) },
-                navigationIcon = {
-                    NavigationBackButton(onNavigateBack)
-                }
-            )
-        },
-        floatingActionButton = {
-            JobAnimatedFloatingActionButton(
-                modifier = Modifier
-                    .imePadding()
-                    .testTag(TEST_TAG_CREATE_PERSONAL_CONVERSATION_BUTTON),
-                enabled = canCreateConversation,
-                startJob = viewModel::createConversation,
-                onJobCompleted = { conversation ->
-                    if (conversation != null) {
-                        onConversationCreated(conversation.id)
-                    } else {
-                        displayCreateConversationFailedDialog = true
-                    }
-                }
-            ) {
-                Row(
-                    modifier = Modifier.padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(pluralStringResource(R.plurals.create_personal_conversation_members, numberOfSelectedUsers, numberOfSelectedUsers))
-                    Icon(Icons.Default.ChevronRight, contentDescription = null)
-                }
-            }
-        }
-    ) { padding ->
-        MemberSelection(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = padding.calculateTopPadding() + Spacings.ScreenTopBarSpacing)
-                .padding(horizontal = Spacings.ScreenHorizontalSpacing)
-                .consumeWindowInsets(WindowInsets.systemBars.only(WindowInsetsSides.Top)),
-            viewModel = viewModel,
-            onUpdateSelectedUserCount = { numberOfSelectedUsers = it }
-        )
-    }
-
-    if (displayCreateConversationFailedDialog) {
-        TextAlertDialog(
-            title = stringResource(id = R.string.create_personal_conversation_failed_title),
-            text = stringResource(id = R.string.create_personal_conversation_failed_message),
-            confirmButtonText = stringResource(id = R.string.create_personal_conversation_failed_positive),
-            dismissButtonText = null,
-            onPressPositiveButton = { displayCreateConversationFailedDialog = false },
-            onDismissRequest = { displayCreateConversationFailedDialog = false }
-        )
-    }
 }

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/add_members/ConversationAddMembersScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/add_members/ConversationAddMembersScreen.kt
@@ -1,42 +1,16 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.settings.add_members
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Done
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import de.tum.informatics.www1.artemis.native_app.core.ui.AwaitDeferredCompletion
-import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
-import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
-import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.ArtemisTopAppBar
-import de.tum.informatics.www1.artemis.native_app.core.ui.compose.JobAnimatedFloatingActionButton
-import de.tum.informatics.www1.artemis.native_app.core.ui.compose.NavigationBackButton
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.MemberSelection
-import kotlinx.coroutines.Deferred
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common.ConversationUserSelectionScreen
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -49,104 +23,30 @@ fun ConversationAddMembersScreen(
     conversationId: Long,
     onNavigateBack: () -> Unit
 ) {
-    ConversationAddMembersScreen(
-        modifier = modifier,
-        viewModel = koinViewModel { parametersOf(courseId, conversationId) },
-        onNavigateBack
-    )
-}
-
-@Composable
-internal fun ConversationAddMembersScreen(
-    modifier: Modifier,
-    viewModel: ConversationAddMembersViewModel,
-    onNavigateBack: () -> Unit
-) {
+    val viewModel = koinViewModel<ConversationAddMembersViewModel> { parametersOf(courseId, conversationId) }
     val canAdd by viewModel.canAdd.collectAsState()
-    var addDeferred: Deferred<Boolean>? by remember { mutableStateOf(null) }
+    var displayFailedDialog by remember { mutableStateOf(false) }
 
-    var displayAddMembersFailedDialog by remember { mutableStateOf(false) }
-    var numberOfSelectedUsers by remember { mutableIntStateOf(0) }
-
-    AwaitDeferredCompletion(job = addDeferred) { successful ->
-        addDeferred = null
-
-        if (successful) {
-            onNavigateBack()
-        } else {
-            displayAddMembersFailedDialog = true
-        }
-    }
-
-    Scaffold(
+    ConversationUserSelectionScreen(
         modifier = modifier,
-        topBar = {
-            ArtemisTopAppBar(
-                title = { Text(text = stringResource(id = R.string.conversation_add_members_title)) },
-                navigationIcon = {
-                    NavigationBackButton(
-                        imageVector = Icons.Default.Close,
-                        onNavigateBack = onNavigateBack
-                    )
-                }
-            )
-        },
-        floatingActionButton = {
-            JobAnimatedFloatingActionButton(
-                modifier = Modifier
-                    .imePadding()
-                    .testTag(TEST_TAG_ADD_MEMBERS_BUTTON),
-                enabled = canAdd,
-                startJob = viewModel::addMembers,
-                onJobCompleted = { successful ->
-                    if (successful) {
-                        onNavigateBack()
-                    } else {
-                        displayAddMembersFailedDialog = true
-                    }
-                }
-            ) {
-                Row(
-                    modifier = Modifier.padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = pluralStringResource(
-                            R.plurals.create_personal_conversation_members,
-                            numberOfSelectedUsers,
-                            numberOfSelectedUsers
-                        )
-                    )
-
-                    Icon(
-                        modifier = Modifier
-                            .padding(start = 8.dp),
-                        imageVector = Icons.Default.Done,
-                        contentDescription = null
-                    )
-                }
+        viewModel = viewModel,
+        fabTestTag = TEST_TAG_ADD_MEMBERS_BUTTON,
+        fabIcon = Icons.Default.Done,
+        titleRes = R.string.conversation_add_members_title,
+        dialogTitleRes = R.string.create_personal_conversation_failed_title,
+        dialogMessageRes = R.string.create_personal_conversation_failed_message,
+        dialogConfirmTextRes = R.string.create_personal_conversation_failed_positive,
+        canSubmit = canAdd,
+        startJob = viewModel::addMembers,
+        onJobCompleted = { success ->
+            if (success == true) {
+                onNavigateBack()
+            } else {
+                displayFailedDialog = true
             }
-        }
-    ) { paddingValues ->
-        MemberSelection(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = paddingValues.calculateTopPadding() + Spacings.ScreenTopBarSpacing)
-                .padding(horizontal = Spacings.ScreenHorizontalSpacing)
-                .consumeWindowInsets(WindowInsets.systemBars.only(WindowInsetsSides.Top)),
-            viewModel = viewModel,
-            onUpdateSelectedUserCount = { numberOfSelectedUsers = it }
-        )
-    }
-
-    if (displayAddMembersFailedDialog) {
-        TextAlertDialog(
-            title = stringResource(id = R.string.conversation_add_members_failed_dialog_title),
-            text = stringResource(id = R.string.conversation_add_members_failed_dialog_message),
-            confirmButtonText = stringResource(id = R.string.conversation_add_members_failed_dialog_positive),
-            dismissButtonText = null,
-            onPressPositiveButton = { displayAddMembersFailedDialog = false },
-            onDismissRequest = { displayAddMembersFailedDialog = false }
-        )
-    }
+        },
+        onNavigateBack = onNavigateBack,
+        displayFailedDialog = displayFailedDialog,
+        onDismissFailedDialog = { displayFailedDialog = false }
+    )
 }

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/overview/ConversationInfoSettings.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/settings/overview/ConversationInfoSettings.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
-import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.PotentiallyIllegalTextField
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common.PotentiallyIllegalTextField
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.Conversation
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.GroupChat

--- a/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/members/ConversationAddMemberSettingsE2eTest.kt
+++ b/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/members/ConversationAddMemberSettingsE2eTest.kt
@@ -19,7 +19,7 @@ import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.DefaultTi
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.user1Username
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.user2Username
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.user3Username
-import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.settings.add_members.ConversationAddMembersScreen
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common.ConversationUserSelectionScreen
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.settings.add_members.ConversationAddMembersViewModel
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.settings.add_members.TEST_TAG_ADD_MEMBERS_BUTTON
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.R
@@ -89,10 +89,18 @@ class ConversationAddMemberSettingsE2eTest : ConversationBaseTest() {
         var isDone = false
 
         composeTestRule.setContent {
-            ConversationAddMembersScreen(
+            ConversationUserSelectionScreen(
                 modifier = Modifier.fillMaxSize(),
                 viewModel = viewModel,
-                onNavigateBack = { isDone = true }
+                displayFailedDialog = false,
+                fabTestTag = TEST_TAG_ADD_MEMBERS_BUTTON,
+                canSubmit = true,
+                startJob = viewModel::addMembers,
+                onJobCompleted = {
+                    isDone = it == true
+                },
+                onNavigateBack = { isDone = true },
+                onDismissFailedDialog = {}
             )
         }
 

--- a/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/overview/CreateConversationE2eTest.kt
+++ b/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/overview/CreateConversationE2eTest.kt
@@ -19,7 +19,7 @@ import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.DefaultTi
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.user2DisplayName
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.user2Username
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.user3Username
-import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_personal_conversation.CreatePersonalConversationScreen
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common.ConversationUserSelectionScreen
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_personal_conversation.CreatePersonalConversationViewModel
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_personal_conversation.TEST_TAG_CREATE_PERSONAL_CONVERSATION_BUTTON
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.CourseUser
@@ -137,11 +137,20 @@ class CreateConversationE2eTest : ConversationBaseTest() {
         )
 
         composeTestRule.setContent {
-            CreatePersonalConversationScreen(
+            ConversationUserSelectionScreen(
                 modifier = Modifier.fillMaxSize(),
                 viewModel = viewModel,
-                onConversationCreated = onConversationCreated,
-                onNavigateBack = {}
+                displayFailedDialog = false,
+                fabTestTag = TEST_TAG_CREATE_PERSONAL_CONVERSATION_BUTTON,
+                canSubmit = true,
+                startJob = viewModel::createConversation,
+                onJobCompleted = { conversation ->
+                    if (conversation != null) {
+                        onConversationCreated(conversation.id)
+                    }
+                },
+                onNavigateBack = {},
+                onDismissFailedDialog = {}
             )
         }
 


### PR DESCRIPTION
### Problem Description

There were two very similar composables as described in #376.

### Changes
This PR introduces a new Composable `ConversationUserSelectionScreen`, which holds the common logic of both views. 
This PR fixes #376 

### Steps for testing
1. Go to the conversation overview.
2. Create a new chat.
3. Add members, click the create button and make sure the chat is correctly created.
4. Head over to the newly created chat and go to the conversation settings.
5. Click on add members.
6. Add new members and make sure everything works as expected.