### PR TITLE
`Feature`: Show user profile pictures in mention search

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/Spacings.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/Spacings.kt
@@ -41,6 +41,8 @@ object Spacings {
         val HintHorizontalPadding = 16.dp
         val ContentVerticalPadding = 8.dp
 
+        val tonalElevation = 2.dp
+        val shadowElevation = 3.dp
     }
 
 

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/ArtemisPopupSurface.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/ArtemisPopupSurface.kt
@@ -1,0 +1,22 @@
+package de.tum.informatics.www1.artemis.native_app.core.ui.compose
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
+
+@Composable
+fun ArtemisPopupSurface(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large,
+        tonalElevation = Spacings.Popup.tonalElevation,
+        shadowElevation = Spacings.Popup.shadowElevation,
+    ) {
+        content()
+    }
+}

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/AutoCompleteHint.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/AutoCompleteHint.kt
@@ -3,12 +3,16 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 import androidx.compose.ui.graphics.vector.ImageVector
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.profile_picture.ProfilePictureData
 
-data class AutoCompleteHint(
-    val hint: String,
-    val replacementText: String,
-    val id: String,
-    val icon: AutoCompleteIcon? = null
-)
+interface AutoCompleteHint {
+    data class Data(
+        val hint: String,
+        val replacementText: String,
+        val id: String,
+        val icon: AutoCompleteIcon? = null
+    ) : AutoCompleteHint
+
+    data object UserSearchQueryTooShort : AutoCompleteHint
+}
 
 sealed class AutoCompleteIcon {
     data class ProfilePicture(val pictureData: ProfilePictureData) : AutoCompleteIcon()

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/AutoCompletionUseCase.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/AutoCompletionUseCase.kt
@@ -29,6 +29,8 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.d
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.Conversation
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.service.network.ConversationService
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.common.getChannelIconImageVector
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.MemberSelectionBaseViewModel
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.profile_picture.ProfilePictureData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -101,16 +103,25 @@ class AutoCompletionUseCase(
         }
     }
 
-    private fun produceUserMentionAutoCompleteHints(query: String): Flow<DataState<List<AutoCompleteHintCollection>>> =
-        flatMapLatest(
+    private fun produceUserMentionAutoCompleteHints(query: String): Flow<DataState<List<AutoCompleteHintCollection>>> {
+        val queryToShortCollection = AutoCompleteHintCollection(
+            type = AutoCompleteType.USERS,
+            items = listOf(AutoCompleteHint.UserSearchQueryTooShort)
+        )
+        if (query.length < MemberSelectionBaseViewModel.MINIMUM_QUERY_LENGTH) return flowOf(DataState.Success(listOf(queryToShortCollection)))
+
+        return flatMapLatest(
             accountService.authToken,
             serverConfigurationService.serverUrl
         ) { authToken, serverUrl ->
             retryOnInternet(networkStatusProvider.currentNetworkStatus) {
                 conversationService
-                    .searchForCourseMembers(
+                    .searchForPotentialCommunicationParticipants(
                         courseId = metisContext.courseId,
                         query = query,
+                        includeStudents = true,
+                        includeTutors = true,
+                        includeInstructors = true,
                         authToken = authToken,
                         serverUrl = serverUrl
                     )
@@ -118,16 +129,22 @@ class AutoCompletionUseCase(
                         AutoCompleteHintCollection(
                             type = AutoCompleteType.USERS,
                             items = users.map {
-                                AutoCompleteHint(
+                                AutoCompleteHint.Data(
                                     it.name.orEmpty(),
                                     replacementText = "[user]${it.name}(${it.username})[/user]",
-                                    id = it.username.orEmpty()
+                                    id = it.username.orEmpty(),
+                                    icon = AutoCompleteIcon.ProfilePicture(
+                                        ProfilePictureData.fromAccount(
+                                            it
+                                        )
+                                    )
                                 )
                             }
                         ).let(::listOf)
                     }
             }
         }
+    }
 
     private fun produceExerciseAndLectureAutoCompleteHints(query: String): Flow<DataState<List<AutoCompleteHintCollection>>> =
         course.map { courseDataState ->
@@ -148,7 +165,7 @@ class AutoCompletionUseCase(
                         val exerciseId = exercise.id ?: return@mapNotNull null
                         val link = ExerciseDeeplinks.ToExercise.markdownLink(courseId, exerciseId)
 
-                        AutoCompleteHint(
+                        AutoCompleteHint.Data(
                             hint = exerciseTitle,
                             replacementText = "[$exerciseTag]${exercise.title}($link)[/$exerciseTag]",
                             id = "Exercise:$exerciseId",
@@ -162,7 +179,7 @@ class AutoCompletionUseCase(
                         val lectureId = lecture.id ?: return@mapNotNull null
                         val link = LectureDeeplinks.ToLecture.markdownLink(courseId, lectureId)
 
-                        AutoCompleteHint(
+                        AutoCompleteHint.Data(
                             hint = lecture.title,
                             replacementText = "[lecture]${lecture.title}($link)[/lecture]",
                             id = "Lecture:$lectureId",
@@ -190,7 +207,7 @@ class AutoCompletionUseCase(
                     .filterIsInstance<ChannelChat>()
                     .filter { it.name.contains(query, ignoreCase = true) }
                     .map { channel ->
-                        AutoCompleteHint(
+                        AutoCompleteHint.Data(
                             hint = channel.name,
                             replacementText = "[channel]${channel.name}(${channel.id})[/channel]",
                             id = "Channel:${channel.id}",
@@ -218,7 +235,7 @@ class AutoCompletionUseCase(
                     .filter { it.questionTitle.contains(query, ignoreCase = true) }
                     .map { faq ->
                         val link = FaqDeeplinks.ToFaq.markdownLink(courseId, faq.id)
-                        AutoCompleteHint(
+                        AutoCompleteHint.Data(
                             hint = faq.questionTitle,
                             replacementText = "[faq]${faq.questionTitle}($link)[/faq]",
                             id = "Faq:${faq.id}",

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/ReplyAutoCompletePopup.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/ReplyAutoCompletePopup.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Keyboard
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -37,7 +39,10 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
+import de.tum.informatics.www1.artemis.native_app.core.ui.common.EmptyListHint
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.dropShadowBelow
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.R
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.MemberSelectionBaseViewModel
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.profile_picture.ProfilePicture
 
 const val TEST_TAG_REPLY_AUTO_COMPLETE_POPUP_LIST = "TEST_TAG_REPLY_AUTO_COMPLETE_POPUP_LIST"
@@ -93,12 +98,28 @@ private fun ReplyAutoCompletePopupBody(
             }
 
             category.items.fastForEachIndexed { i, hint ->
-                item(key = "${category.type}_${hint.id}") {
-                    AutoCompleteHintComposable(
-                        modifier = Modifier.fillMaxWidth(),
-                        hint = hint,
-                        onClick = { performAutoComplete(hint.replacementText) }
-                    )
+                when (hint) {
+                    is AutoCompleteHint.UserSearchQueryTooShort -> {
+                        item {
+                            EmptyListHint(
+                                modifier = Modifier.fillMaxWidth(),
+                                imageVector = Icons.Default.Keyboard,
+                                hint = stringResource(id = R.string.conversation_member_selection_query_too_short_popup,
+                                    MemberSelectionBaseViewModel.MINIMUM_QUERY_LENGTH
+                                )
+                            )
+                        }
+                    }
+
+                    is AutoCompleteHint.Data -> {
+                        item(key = "${category.type}_${hint.id}") {
+                            AutoCompleteHintComposable(
+                                modifier = Modifier.fillMaxWidth(),
+                                hint = hint,
+                                onClick = { performAutoComplete(hint.replacementText) }
+                            )
+                        }
+                    }
                 }
 
                 if (i != category.items.lastIndex) {
@@ -138,7 +159,7 @@ private fun AutoCompleteCategoryComposable(modifier: Modifier, name: String) {
 @Composable
 private fun AutoCompleteHintComposable(
     modifier: Modifier,
-    hint: AutoCompleteHint,
+    hint: AutoCompleteHint.Data,
     onClick: () -> Unit
 ) {
     val horizontalPadding = Spacings.Popup.HintHorizontalPadding
@@ -188,7 +209,7 @@ private fun ReplyAutoCompletePopupBodyPreview() {
             AutoCompleteHintCollection(
                 type = AutoCompleteType.USERS,
                 items = (0 until 1).map {
-                    AutoCompleteHint(
+                    AutoCompleteHint.Data(
                         hint = "Hint $it",
                         replacementText = "",
                         id = it.toString() + "a"
@@ -198,7 +219,7 @@ private fun ReplyAutoCompletePopupBodyPreview() {
             AutoCompleteHintCollection(
                 type = AutoCompleteType.USERS,
                 items = (0 until 1).map {
-                    AutoCompleteHint(
+                    AutoCompleteHint.Data(
                         hint = "Hint $it",
                         replacementText = "",
                         id = it.toString() + "b"
@@ -208,7 +229,7 @@ private fun ReplyAutoCompletePopupBodyPreview() {
             AutoCompleteHintCollection(
                 type = AutoCompleteType.USERS,
                 items = (0 until 1).map {
-                    AutoCompleteHint(
+                    AutoCompleteHint.Data(
                         hint = "Hint $it",
                         replacementText = "",
                         id = it.toString() + "c"

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/ReplyAutoCompletePopup.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/ReplyAutoCompletePopup.kt
@@ -3,8 +3,6 @@ package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,14 +15,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Keyboard
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -40,6 +37,7 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.EmptyListHint
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.ArtemisPopupSurface
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.MemberSelectionBaseViewModel
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.profile_picture.ProfilePicture
@@ -79,57 +77,52 @@ private fun ReplyAutoCompletePopupBody(
     autoCompleteCategories: List<AutoCompleteHintCollection>,
     performAutoComplete: (replacement: String) -> Unit
 ) {
-    LazyColumn(
+    ArtemisPopupSurface(
         modifier = modifier
-            .clip(MaterialTheme.shapes.large)
-            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
-            .padding(8.dp)
-            .testTag(TEST_TAG_REPLY_AUTO_COMPLETE_POPUP_LIST)
     ) {
+        LazyColumn(
+            modifier = Modifier
+                .padding(8.dp)
+                .testTag(TEST_TAG_REPLY_AUTO_COMPLETE_POPUP_LIST)
+        ) {
 
-        autoCompleteCategories.forEachIndexed { categoryIndex, category ->
-            stickyHeader {
-                AutoCompleteCategoryComposable(
-                    modifier = Modifier.fillMaxWidth(),
-                    name = stringResource(id = category.type.title)
-                )
-            }
+            autoCompleteCategories.forEachIndexed { categoryIndex, category ->
+                stickyHeader {
+                    AutoCompleteCategoryComposable(
+                        modifier = Modifier.fillMaxWidth(),
+                        name = stringResource(id = category.type.title)
+                    )
+                }
 
-            category.items.fastForEachIndexed { i, hint ->
-                when (hint) {
-                    is AutoCompleteHint.UserSearchQueryTooShort -> {
-                        item {
-                            EmptyListHint(
-                                modifier = Modifier.fillMaxWidth(),
-                                imageVector = Icons.Default.Keyboard,
-                                hint = stringResource(id = R.string.conversation_member_selection_query_too_short_popup,
-                                    MemberSelectionBaseViewModel.MINIMUM_QUERY_LENGTH
+                category.items.fastForEachIndexed { i, hint ->
+                    when (hint) {
+                        is AutoCompleteHint.UserSearchQueryTooShort -> {
+                            item {
+                                EmptyListHint(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    imageVector = Icons.Default.Keyboard,
+                                    hint = stringResource(
+                                        id = R.string.conversation_member_selection_query_too_short_popup,
+                                        MemberSelectionBaseViewModel.MINIMUM_QUERY_LENGTH
+                                    )
                                 )
-                            )
+                            }
                         }
-                    }
 
-                    is AutoCompleteHint.Data -> {
-                        item(key = "${category.type}_${hint.id}") {
-                            AutoCompleteHintComposable(
-                                modifier = Modifier.fillMaxWidth(),
-                                hint = hint,
-                                onClick = { performAutoComplete(hint.replacementText) }
-                            )
+                        is AutoCompleteHint.Data -> {
+                            item(key = "${category.type}_${hint.id}") {
+                                AutoCompleteHintComposable(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    hint = hint,
+                                    onClick = { performAutoComplete(hint.replacementText) }
+                                )
+                            }
                         }
                     }
                 }
 
-                if (i != category.items.lastIndex) {
-                    item { HorizontalDivider() }
-                }
-            }
-
-            if (categoryIndex != autoCompleteCategories.lastIndex) {
-                item {
-                    Column {
-                        HorizontalDivider()
-
+                if (categoryIndex != autoCompleteCategories.lastIndex) {
+                    item {
                         Spacer(modifier = Modifier.height(8.dp))
                     }
                 }
@@ -140,18 +133,16 @@ private fun ReplyAutoCompletePopupBody(
 
 @Composable
 private fun AutoCompleteCategoryComposable(modifier: Modifier, name: String) {
-    Box(modifier) {
-        Text(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
-                .padding(horizontal = Spacings.Popup.HintHorizontalPadding, vertical = 4.dp),
-            text = name,
-            color = MaterialTheme.colorScheme.primary,
-            style = MaterialTheme.typography.labelLarge,
-            textAlign = TextAlign.Center
-        )
-    }
+    Text(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceColorAtElevation(Spacings.Popup.tonalElevation))
+            .padding(horizontal = Spacings.Popup.HintHorizontalPadding, vertical = 4.dp),
+        text = name,
+        color = MaterialTheme.colorScheme.primary,
+        style = MaterialTheme.typography.labelLarge,
+        textAlign = TextAlign.Center
+    )
 }
 
 @Composable

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/ReplyAutoCompletePopup.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/autocomplete/ReplyAutoCompletePopup.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.EmptyListHint
-import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.dropShadowBelow
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.MemberSelectionBaseViewModel
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.profile_picture.ProfilePicture
@@ -67,8 +66,7 @@ internal fun ReplyAutoCompletePopup(
             modifier = Modifier
                 .padding(vertical = verticalPadding, horizontal = 8.dp)
                 .heightIn(max = maxHeight - verticalPadding * 2)
-                .width(targetWidth)
-                .dropShadowBelow(),
+                .width(targetWidth),
             autoCompleteCategories = autoCompleteCategories,
             performAutoComplete = performAutoComplete
         )

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/BaseChatUITest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/BaseChatUITest.kt
@@ -336,9 +336,9 @@ abstract class BaseChatUITest : BaseComposeTest() {
         AutoCompleteHintCollection(
             type = AutoCompleteType.USERS,
             items = listOf(
-                AutoCompleteHint("User1", "<User1>", "1"),
-                AutoCompleteHint("User2", "<User2>", "2"),
-                AutoCompleteHint("User3", "<User3>", "3"),
+                AutoCompleteHint.Data("User1", "<User1>", "1"),
+                AutoCompleteHint.Data("User2", "<User2>", "2"),
+                AutoCompleteHint.Data("User3", "<User3>", "3"),
             )
         )
     )

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ConversationAutoCompletionE2eTest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ConversationAutoCompletionE2eTest.kt
@@ -1,11 +1,10 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation
 
-import de.tum.informatics.www1.artemis.native_app.core.common.test.EndToEndTest
 import de.tum.informatics.www1.artemis.native_app.core.common.test.DefaultTestTimeoutMillis
-import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.DefaultTimeoutMillis
+import de.tum.informatics.www1.artemis.native_app.core.common.test.EndToEndTest
 import de.tum.informatics.www1.artemis.native_app.core.common.test.testServerUrl
 import de.tum.informatics.www1.artemis.native_app.core.model.account.User
-import de.tum.informatics.www1.artemis.native_app.feature.login.test.user1Username
+import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.DefaultTimeoutMillis
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.user2Username
 import de.tum.informatics.www1.artemis.native_app.feature.login.test.user3Username
 import de.tum.informatics.www1.artemis.native_app.feature.metistest.ConversationBaseTest
@@ -15,8 +14,8 @@ import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.util.Logger
-import kotlin.test.assertTrue
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 
 
@@ -27,7 +26,7 @@ class ConversationAutoCompletionE2eTest : ConversationBaseTest() {
     @Test(timeout = DefaultTestTimeoutMillis)
     fun `test GIVEN users are registered in a course WHEN requesting auto complete users THEN the registered users are returned`() {
         val users = listOf(
-            User(username = user1Username),
+            // Do not include user1, as this is the user that is logged in and should not be included in the auto-complete suggestions
             User(username = user2Username),
             User(username = user3Username)
         )
@@ -35,9 +34,12 @@ class ConversationAutoCompletionE2eTest : ConversationBaseTest() {
         runTest(timeout = DefaultTimeoutMillis.milliseconds) {
 
             val typedText = "user"
-            val autoCompleteSuggestions = conversationService.searchForCourseMembers(
+            val autoCompleteSuggestions = conversationService.searchForPotentialCommunicationParticipants(
                 courseId = course.id!!,
                 query = typedText,
+                includeStudents = true,
+                includeTutors = true,
+                includeInstructors = true,
                 authToken = accessToken,
                 serverUrl = testServerUrl
             ).orThrow("Could not get auto-complete suggestions")

--- a/feature/metis/shared/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ConversationServiceStub.kt
+++ b/feature/metis/shared/src/debug/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ConversationServiceStub.kt
@@ -34,13 +34,6 @@ open class ConversationServiceStub(
         serverUrl: String
     ): NetworkResponse<List<CourseUser>> = NetworkResponse.Response(emptyList())
 
-    override suspend fun searchForCourseMembers(
-        courseId: Long,
-        query: String,
-        authToken: String,
-        serverUrl: String
-    ): NetworkResponse<List<ConversationUser>> = NetworkResponse.Response(emptyList())
-
     override suspend fun createOneToOneConversation(
         courseId: Long,
         partner: String,

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/ConversationService.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/ConversationService.kt
@@ -27,13 +27,6 @@ interface ConversationService {
         serverUrl: String
     ): NetworkResponse<List<CourseUser>>
 
-    suspend fun searchForCourseMembers(
-        courseId: Long,
-        query: String,
-        authToken: String,
-        serverUrl: String
-    ): NetworkResponse<List<ConversationUser>>
-
     suspend fun createOneToOneConversation(
         courseId: Long,
         partnerUserIdentifier: UserIdentifier,

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
@@ -75,25 +75,6 @@ class ConversationServiceImpl(private val ktorProvider: KtorProvider) : Conversa
         }
     }
 
-    override suspend fun searchForCourseMembers(
-        courseId: Long,
-        query: String,
-        authToken: String,
-        serverUrl: String
-    ): NetworkResponse<List<ConversationUser>> {
-        return performNetworkCall {
-            ktorProvider.ktorClient.get(serverUrl) {
-                url {
-                    appendPathSegments(*Api.Core.Courses.path, courseId.toString(), "members", "search")
-
-                    parameter("loginOrName", query)
-                }
-
-                cookieAuth(authToken)
-            }.body()
-        }
-    }
-
     override suspend fun createGroupChat(
         courseId: Long,
         groupMembers: List<String>,

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ui/ConversationExtensions.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ui/ConversationExtensions.kt
@@ -25,5 +25,5 @@ val OneToOneChat.humanReadableTitle: String
 
 val BaseAccount.humanReadableName: String
     get() {
-        return "$firstName $lastName"
+        return name ?: "$firstName $lastName"
     }

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ui/member_selection/MemberSearchWithDropdownPopup.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ui/member_selection/MemberSearchWithDropdownPopup.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Keyboard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,7 +30,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -55,7 +55,7 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.BasicSearchTextField
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.EmptyListHint
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.NoSearchResults
-import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.dropShadowBelow
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.ArtemisPopupSurface
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.member_selection.util.MemberSelectionItem
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.profile_picture.ProfilePicture
@@ -183,80 +183,84 @@ private fun PopupContent(
     onDismissRequest: () -> Unit,
     onAddMemberItem: (MemberSelectionItem) -> Unit
 ) {
-    LazyColumn(
+    ArtemisPopupSurface(
         modifier = modifier
-            .dropShadowBelow()
-            .clip(MaterialTheme.shapes.large)
-            .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
-            .padding(8.dp)
     ) {
-        stickyHeader {
-            PopupHeader(
-                modifier = Modifier.fillMaxWidth(),
-                title = stringResource(id = R.string.conversation_member_selection_channels)
-            )
-        }
-
-        if (conversations.isEmpty()) {
-            item {
-                NoSearchResults(
+        LazyColumn(
+            modifier = Modifier.padding(8.dp)
+        ) {
+            stickyHeader {
+                PopupHeader(
                     modifier = Modifier.fillMaxWidth(),
-                    title = stringResource(id = R.string.conversation_member_selection_channels_no_search_results_title),
-                    details = stringResource(
-                        id = R.string.conversation_member_selection_channels_no_search_results_details,
-                        query
-                    ),
-                    showIcon = false
+                    title = stringResource(id = R.string.conversation_member_selection_channels)
                 )
             }
-        } else {
-            conversations.forEach { item ->
+
+            if (conversations.isEmpty()) {
                 item {
-                    PopupItem(
+                    NoSearchResults(
                         modifier = Modifier.fillMaxWidth(),
-                        item = item,
-                        onAddMemberItem = onAddMemberItem,
-                        onDismissRequest = onDismissRequest
+                        title = stringResource(id = R.string.conversation_member_selection_channels_no_search_results_title),
+                        details = stringResource(
+                            id = R.string.conversation_member_selection_channels_no_search_results_details,
+                            query
+                        ),
+                        showIcon = false
                     )
                 }
+            } else {
+                conversations.forEach { item ->
+                    item {
+                        PopupItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            item = item,
+                            onAddMemberItem = onAddMemberItem,
+                            onDismissRequest = onDismissRequest
+                        )
+                    }
+                }
             }
-        }
 
-        stickyHeader {
-            PopupHeader(
-                modifier = Modifier.fillMaxWidth(),
-                title = stringResource(id = R.string.conversation_member_selection_users)
-            )
-        }
-
-        if (recipients.isEmpty() && query.length < MemberSelectionBaseViewModel.MINIMUM_QUERY_LENGTH) {
-            item {
-                EmptyListHint(
+            stickyHeader {
+                PopupHeader(
                     modifier = Modifier.fillMaxWidth(),
-                    imageVector = Icons.Default.Keyboard,
-                    hint = stringResource(id = R.string.conversation_member_selection_query_too_short_popup,
-                        MemberSelectionBaseViewModel.MINIMUM_QUERY_LENGTH
-                    )
+                    title = stringResource(id = R.string.conversation_member_selection_users)
                 )
             }
-        } else if (recipients.isEmpty()) {
-            item {
-                NoSearchResults(
-                    modifier = Modifier.fillMaxWidth(),
-                    title = stringResource(id = R.string.conversation_member_selection_recipients_no_search_results_title),
-                    details = stringResource(id = R.string.conversation_member_selection_recipients_no_search_results_details, query),
-                    showIcon = false
-                )
-            }
-        } else {
-            recipients.forEach { item ->
+
+            if (recipients.isEmpty() && query.length < MemberSelectionBaseViewModel.MINIMUM_QUERY_LENGTH) {
                 item {
-                    PopupItem(
+                    EmptyListHint(
                         modifier = Modifier.fillMaxWidth(),
-                        item = item,
-                        onAddMemberItem = onAddMemberItem,
-                        onDismissRequest = onDismissRequest
+                        imageVector = Icons.Default.Keyboard,
+                        hint = stringResource(
+                            id = R.string.conversation_member_selection_query_too_short_popup,
+                            MemberSelectionBaseViewModel.MINIMUM_QUERY_LENGTH
+                        )
                     )
+                }
+            } else if (recipients.isEmpty()) {
+                item {
+                    NoSearchResults(
+                        modifier = Modifier.fillMaxWidth(),
+                        title = stringResource(id = R.string.conversation_member_selection_recipients_no_search_results_title),
+                        details = stringResource(
+                            id = R.string.conversation_member_selection_recipients_no_search_results_details,
+                            query
+                        ),
+                        showIcon = false
+                    )
+                }
+            } else {
+                recipients.forEach { item ->
+                    item {
+                        PopupItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            item = item,
+                            onAddMemberItem = onAddMemberItem,
+                            onDismissRequest = onDismissRequest
+                        )
+                    }
                 }
             }
         }
@@ -272,7 +276,7 @@ private fun PopupHeader(
         Text(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = MaterialTheme.colorScheme.surfaceContainerHighest)
+                .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(Spacings.Popup.tonalElevation))
                 .padding(horizontal = Spacings.Popup.HintHorizontalPadding, vertical = 4.dp),
             text = title,
             color = MaterialTheme.colorScheme.primary,


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
Previously we did not display the users profile pictures when searching for user mentions. This was inconsistent to the other places within the app.

This PR closes #329 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Use different API endpoint for fetching user mention suggestions (that includes the imageUrls)
- Display hint if the search query is too short


### Steps for testing
1. Go to any chat
2. Start a user mention by typing "@" or via the mention icon button
3. See that a hint is shown that you need to type at least 3 characters
4. When typing more than 3 chars, the search results are shown with a profile picture

### Screenshots
![image](https://github.com/user-attachments/assets/7d4d79e2-3d87-48cc-93e9-12e372e3809f)
