### PR TITLE
`Improvement`: Fix saved posts paddings

### DIFF
--- a/feature/metis/conversation/saved-posts/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/saved_posts/saved_posts_module.kt
+++ b/feature/metis/conversation/saved-posts/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/saved_posts/saved_posts_module.kt
@@ -12,7 +12,6 @@ val saved_posts_module = module {
     viewModel { params ->
         SavedPostsViewModel(
             params[0],
-            params[1],
             get(),
             get(),
             get(),

--- a/feature/metis/conversation/saved-posts/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/saved_posts/ui/SavedPostsScreen.kt
+++ b/feature/metis/conversation/saved-posts/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/saved_posts/ui/SavedPostsScreen.kt
@@ -63,8 +63,8 @@ fun SavedPostsScreen(
     onNavigateToPost: (ISavedPost) -> Unit
 ) {
     val viewModel = koinViewModel<SavedPostsViewModel>(
-        key = "$courseId|$savedPostStatus"
-    ) { parametersOf(courseId, savedPostStatus) }
+        key = "$courseId"
+    ) { parametersOf(courseId) }
 
     LaunchedEffect(viewModel) {
         viewModel.onRequestReload()

--- a/feature/metis/conversation/saved-posts/src/main/res/values/saved_posts_strings.xml
+++ b/feature/metis/conversation/saved-posts/src/main/res/values/saved_posts_strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="saved_posts_title_prefix">Saved Messages</string>
+    <string name="saved_posts_screen_title">Saved Messages</string>
     <string name="saved_posts_removal_notice"> Archived and completed bookmarks will be removed after 100 days.</string>
 
     <string name="saved_posts_loading_posts_loading">Fetching saved posts from the server …</string>

--- a/feature/metis/conversation/saved-posts/src/test/java/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/saved_posts/SavedPostsScreenUiTest.kt
+++ b/feature/metis/conversation/saved-posts/src/test/java/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/saved_posts/SavedPostsScreenUiTest.kt
@@ -101,7 +101,6 @@ class SavedPostsScreenUiTest : BaseComposeTest() {
     }
 
     private fun setupUi(
-        forStatus: SavedPostStatus = SavedPostStatus.IN_PROGRESS,
         savedPost: ISavedPost = createSavedPost(),
         onChangeStatus: (ISavedPost, SavedPostStatus) -> Deferred<MetisModificationFailure?> = { _, _ -> CompletableDeferred() },
         onRemoveFromSavedPosts: (ISavedPost) -> Deferred<MetisModificationFailure?> = { CompletableDeferred() }
@@ -109,7 +108,6 @@ class SavedPostsScreenUiTest : BaseComposeTest() {
         composeTestRule.setContent {
             SavedPostsScreen(
                 modifier = Modifier,
-                status = forStatus,
                 savedPostsDataState = DataState.Success(listOf(savedPost)),
                 onRequestReload = {},
                 onNavigateToPost = { _ -> },

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationList.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationList.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -41,7 +42,6 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -109,8 +109,6 @@ internal fun ConversationList(
     onToggleMuted: (conversationId: Long, muted: Boolean) -> Unit,
     trailingContent: LazyListScope.() -> Unit
 ) {
-    val isSavedPostsExpanded by viewModel.isSavedPostsExpanded.collectAsState()
-
     ConversationList(
         modifier = modifier,
         toggleFavoritesExpanded = viewModel::toggleFavoritesExpanded,
@@ -285,10 +283,23 @@ internal fun ConversationList(
     }
 }
 
+private fun LazyListScope.savedPostsHeaderRow(
+    onClick: () -> Unit
+) {
+    conversationSectionHeader(
+        key = SECTION_SAVED_POSTS_KEY,
+        text = R.string.conversation_overview_section_saved_posts,
+        isExpanded = null,
+        unreadCount = 0,
+        onClick = onClick,
+        icon = { Icon(imageVector = Icons.Default.Bookmark, contentDescription = null) }
+    )
+}
+
 private fun LazyListScope.conversationSectionHeader(
     key: String,
     @StringRes text: Int,
-    isExpanded: Boolean,
+    isExpanded: Boolean?,
     conversationCount: Int? = null,
     unreadCount: Long,
     onClick: () -> Unit,
@@ -301,6 +312,7 @@ private fun LazyListScope.conversationSectionHeader(
                 .animateItem()
                 .testTag(key)
                 .clickable { onClick() }
+                .heightIn(min = 64.dp)      // If isExpanded is null, then the height is smaller because of the missing icon button
                 .padding(vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
@@ -317,6 +329,10 @@ private fun LazyListScope.conversationSectionHeader(
                     text = if (conversationCount != null) stringResource(id = text, conversationCount) else stringResource(id = text),
                     style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
                 )
+            }
+
+            if (isExpanded == null) {
+                return@item
             }
 
             if (!isExpanded) UnreadMessages(unreadMessagesCount = unreadCount)
@@ -642,34 +658,4 @@ private fun String.removeSectionPrefix(): String {
         }
     }
     return result.trim()
-}
-
-private fun LazyListScope.savedPostsHeaderRow(
-    onClick: () -> Unit
-) {
-    item(key = SECTION_SAVED_POSTS_KEY) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag(SECTION_SAVED_POSTS_KEY)
-                .clickable { onClick() }
-                .padding(vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.weight(1f)
-            ) {
-                Icon(imageVector = Icons.Default.Bookmark, contentDescription = null)
-                Text(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(start = 8.dp),
-                    text = stringResource(R.string.conversation_overview_section_saved_posts),
-                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
-                )
-            }
-        }
-    }
 }

--- a/feature/metis/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/ui/SinglePageConversationBody.kt
+++ b/feature/metis/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/ui/SinglePageConversationBody.kt
@@ -28,7 +28,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.NothingOpened
 import de.tum.informatics.www1.artemis.native_app.feature.metis.OpenedConversation
 import de.tum.informatics.www1.artemis.native_app.feature.metis.OpenedSavedPosts
 import de.tum.informatics.www1.artemis.native_app.feature.metis.OpenedThread
-import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.saved_posts.ui.SavedPostsScreenWithChips
+import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.saved_posts.ui.SavedPostsScreen
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.ConversationScreen
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.browse_channels.BrowseChannelsScreen
@@ -197,7 +197,7 @@ internal fun SinglePageConversationBody(
                 is OpenedSavedPosts -> {
                     // TODO: This should potentially be moved into the ConversationScreen. That allows us to still display the ConvOverview on the left.
                     //      https://github.com/ls1intum/artemis-android/issues/288
-                    SavedPostsScreenWithChips(
+                    SavedPostsScreen(
                         modifier = modifier,
                         courseId = courseId,
                         onNavigateToPost = { savedPost ->


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
There were some padding and window insets issues with the redesigned saved posts screen:
- Extra padding around status selection row
- Window insets at bottom are not considered correctly
![image](https://github.com/user-attachments/assets/250d34d7-b561-4747-b2a8-b801aa9dc0b6)


### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
- Made the padding of the status selection row smaller
- Fixed window insets for the navigationbar
- Made saved messages section in conversation overview bigger
- Smaller UI refactorings

### Steps for testing
See that the padding looks nice now

### Screenshots
Now:
![image](https://github.com/user-attachments/assets/664637fe-cfa7-43b5-9fef-11f92c03550d)
