### PR TITLE
`Improvement`: Exercise view adjustments

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/ArtemisWebView.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/ArtemisWebView.kt
@@ -137,6 +137,18 @@ private class ThemeClient(
             if (adjustHeightForContent) {
                 val delay = 750L
 
+                view.evaluateJavascript(
+                    """
+                        (function applyBackgroundColorToAllDivs(color) {
+                            const allDivs = document.querySelectorAll('div');
+                            allDivs.forEach(el => {
+                                el.style.backgroundColor = color;
+                            });
+                        })('transparent');
+                    """.trimIndent(),
+                    null
+                )
+
                 view.postDelayed({
                     view.evaluateJavascript(
                         """

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/ArtemisWebView.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/compose/ArtemisWebView.kt
@@ -135,8 +135,9 @@ private class ThemeClient(
             // The following code is inspired by: https://github.com/ls1intum/artemis-ios/blob/71596a9949bacd29c142cbdfe3a9825d6921628f/ArtemisKit/Sources/CourseView/ExerciseTab/ExerciseDetailViewModel.swift
             // The code can be found in the artemis-ios repository: https://github.com/ls1intum/artemis-ios
             if (adjustHeightForContent) {
-                val delay = 750L
+                val delay = 750L // This delay is needed to ensure that the page is fully loaded before we try to get the height
 
+                // Set the background color of all divs to transparent to avoid white background
                 view.evaluateJavascript(
                     """
                         (function applyBackgroundColorToAllDivs(color) {
@@ -149,6 +150,7 @@ private class ThemeClient(
                     null
                 )
 
+                // Get the height of the content after delay
                 view.postDelayed({
                     view.evaluateJavascript(
                         """

--- a/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
+++ b/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.web.WebViewState
 import de.tum.informatics.www1.artemis.native_app.core.model.exercise.Exercise
@@ -71,7 +72,19 @@ internal fun ExerciseOverviewTab(
 
         Spacer(modifier = Modifier.height(16.dp))
 
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacings.ScreenHorizontalSpacing),
+            text = stringResource(id = R.string.exercise_view_overview_problem_statement),
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.Medium
+            )
+        )
+
         if (exercise !is QuizExercise && webViewState != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+
             ArtemisWebView(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -86,7 +99,9 @@ internal fun ExerciseOverviewTab(
                 text = stringResource(id = R.string.exercise_view_overview_problem_statement_not_available),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp)
+                    .padding(horizontal = Spacings.ScreenHorizontalSpacing),
+                color = MaterialTheme.colorScheme.secondary,
+                style = MaterialTheme.typography.bodyMedium
             )
         }
     }

--- a/feature/exercise-view/src/main/res/values/exercise_view_strings.xml
+++ b/feature/exercise-view/src/main/res/values/exercise_view_strings.xml
@@ -35,6 +35,7 @@
 
     <string name="exercise_participation_status_title">Your exercise status:</string>
 
+    <string name="exercise_view_overview_problem_statement">Problem Statement</string>
     <string name="exercise_view_overview_problem_statement_not_available">No problem statement available.</string>
 
     <string name="exercise_info_title">Exercise info</string>


### PR DESCRIPTION
### Problem Description

The exercise view has no label to indicate the start of the problem statement and the problem statement comes with a gray background, which does not fit the rest of the view.

### Changes

This PR fixes the problems described above, by adding a new label and injecting a javascript code block to change the background color.

### Steps for testing

Make sure everything looks good and works as expected.

### Screenshots

<img src="https://github.com/user-attachments/assets/dd4c615b-84bf-4725-a23e-e7312b411394" data-canonical-src="https://github.com/user-attachments/assets/dd4c615b-84bf-4725-a23e-e7312b411394" height="700" />
