### PR TITLE
`Bugfix`: Fix fileupload url

### DIFF
--- a/build-logic/convention/src/main/kotlin/commonConfiguration/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/commonConfiguration/KotlinAndroid.kt
@@ -134,7 +134,7 @@ internal fun Project.configureReleaseTypeFlavors(
     }
 }
 
-private const val TUM_ARTEMIS_SERVER_URL = "https://artemis.tum.de"
+private const val TUM_ARTEMIS_SERVER_URL = "https://artemis.tum.de/"        // The "/" at the end is important, as it is used in the URL building process
 
 internal fun Project.configureInstanceSelectionFlavors(
     commonExtension: CommonExtension<*, *, *, *, *, *>,

--- a/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/impl/ServerConfigurationServiceImpl.kt
+++ b/core/datastore/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/datastore/impl/ServerConfigurationServiceImpl.kt
@@ -56,8 +56,15 @@ internal class ServerConfigurationServiceImpl(
     }
 
     override suspend fun updateServerUrl(serverUrl: String) {
+        // The server URL must end with a trailing slash
+        val actualUrl = if (!serverUrl.endsWith("/")) {
+            "$serverUrl/"
+        } else {
+            serverUrl
+        }
+
         context.serverCommunicationPreferences.edit { data ->
-            data[SERVER_URL_KEY] = serverUrl
+            data[SERVER_URL_KEY] = actualUrl
         }
     }
 }

--- a/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/custom_instance_selection/CustomInstanceSelectionScreen.kt
+++ b/feature/login/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/login/custom_instance_selection/CustomInstanceSelectionScreen.kt
@@ -70,13 +70,7 @@ internal class CustomInstanceSelectionViewModel(
 
     fun setCustomInstance(onDone: () -> Unit) {
         viewModelScope.launch {
-            val actualUrl = if (!serverUrl.value.endsWith("/")) {
-                serverUrl.value + "/"
-            } else {
-                serverUrl.value
-            }
-
-            serverConfigurationService.updateServerUrl(actualUrl)
+            serverConfigurationService.updateServerUrl(serverUrl.value)
             onDone()
         }
     }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
After installing the Android app, the default serverUrl was set to the tum instance, but the slash was missing from the serverUrl. This caused a bug where file uploads incorrectly formatted the path to the uploaded file.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
This PR fixes this bug

### Steps for testing
- Uninstall and re-install the app
- Upload a file to a chat
- See that the uploaded image can be viewed
