### PR TITLE
`Bugfix`: Fix Push Notification Serialization Error

### DIFF
--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/notification_model/ArtemisNotification.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/notification_model/ArtemisNotification.kt
@@ -96,7 +96,7 @@ object SafeInstantSerializer : KSerializer<Instant> {
         PrimitiveSerialDescriptor("SafeInstant", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): Instant {
-        val raw = decoder.decodeString()
+        val raw = decoder.decodeString()            // eg "2025-05-04T11:28:18.762036099Z[Etc/UTC]"
         val cleaned = raw.substringBefore('[')
         return Instant.parse(cleaned)
     }


### PR DESCRIPTION
### Problem Description

Due to a recent change in the backend, the date included in the push-notifications is in a different format. This format is incompatible with the standard serializer.

### Changes

This PR adds a custom serializer, that deserializes the push-notification correctly.
Dates in this format `2025-05-04T11:28:18.762036099Z[Etc/UTC]` are now converted to this format `2025-05-04T11:28:18.762036099Z` before deserialization.

### Steps for testing

1. Make sure push notifications for messages are enabled. (Go to a course on the web app and check the course settings).
2. Go to a channel on the web app.
3. Send a message
4. Verify, that a push notification gets delivered correctly.
