### PR TITLE
`Improvement`: Disable Notification Settings categories

### DIFF
--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingsUi.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/ui/PushNotificationSettingsUi.kt
@@ -2,7 +2,6 @@ package de.tum.informatics.www1.artemis.native_app.feature.push.ui
 
 import android.Manifest
 import android.os.Build
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -36,6 +35,7 @@ import com.google.accompanist.permissions.rememberPermissionState
 import de.tum.informatics.www1.artemis.native_app.core.data.DataState
 import de.tum.informatics.www1.artemis.native_app.core.ui.Scaling
 import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
+import de.tum.informatics.www1.artemis.native_app.core.ui.common.InfoMessageCard
 import de.tum.informatics.www1.artemis.native_app.core.ui.material.colors.linkTextColor
 import de.tum.informatics.www1.artemis.native_app.feature.push.R
 import kotlinx.coroutines.Job
@@ -56,6 +56,11 @@ fun PushNotificationSettingsUi(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        InfoMessageCard(
+            modifier = Modifier.fillMaxWidth(),
+            infoText = stringResource(id = R.string.push_notification_settings_explanation),
+        )
+
         ReceivePushNotificationsSwitch(
             modifier = Modifier.fillMaxWidth(),
             isChecked = arePushNotificationEnabled,
@@ -71,21 +76,24 @@ fun PushNotificationSettingsUi(
             }
         )
 
-        AnimatedVisibility(visible = arePushNotificationEnabled) {
-            PushNotificationSettingCategoriesListUi(
-                modifier = Modifier.fillMaxWidth(),
-                settingsByGroupDataState = settingsByGroupDataStore,
-                onUpdate = { setting, webapp, email, push ->
-                    viewModel.updateSettingsEntry(
-                        setting.settingId,
-                        email,
-                        webapp,
-                        push
-                    )
-                },
-                onRequestReload = viewModel::onRequestReload
-            )
-        }
+        // The following code is commented out because fine-graining the settings has to be adjusted
+        // to the the new endpoint with the new course-specific notification system
+
+        //AnimatedVisibility(visible = arePushNotificationEnabled) {
+        //    PushNotificationSettingCategoriesListUi(
+        //        modifier = Modifier.fillMaxWidth(),
+        //        settingsByGroupDataState = settingsByGroupDataStore,
+        //        onUpdate = { setting, webapp, email, push ->
+        //            viewModel.updateSettingsEntry(
+        //                setting.settingId,
+        //                email,
+        //                webapp,
+        //                push
+        //            )
+        //        },
+        //        onRequestReload = viewModel::onRequestReload
+        //    )
+        //}
     }
 
     if (updatePushNotificationEnabledJob != null) {

--- a/feature/push/src/main/res/values/push_notification_settings_strings.xml
+++ b/feature/push/src/main/res/values/push_notification_settings_strings.xml
@@ -3,7 +3,7 @@
     <string name="push_notification_settings_receive_label">Receive push notifications on this device?</string>
     <string name="push_notification_settings_receive_information">When push notifications are enabled, your device will communicate with third party services, such as Google. Push notifications are end-to-end encrypted. Therefore, third parties cannot read the content of the push notifications you receive. Push notifications are entirely optional.</string>
     <string name="push_notification_settings_receive_information_expand">Click to read more…</string>
-
+    <string name="push_notification_settings_explanation">You can adjust the notification settings for each course on the web app.</string>
 
     <string name="push_notification_settings_loading">Loading settings…</string>
     <string name="push_notification_settings_failure">Something went wrong while loading your settings</string>


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description

With the new course-specific notification system it is not possible to fine-grain the global notification settings.

### Changes

This PR removes the options for the notification settings.

### Steps for testing

Make sure everything works as expected.
