### PR TITLE
`Communication`: Remove message background

### DIFF
--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/post/PostWithBottomSheet.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/post/PostWithBottomSheet.kt
@@ -64,15 +64,13 @@ internal fun PostWithBottomSheet(
 
     val isPinned = post is IStandalonePost && post.displayPriority == DisplayPriority.PINNED
     val isResolving = post is IAnswerPost && post.resolvesPost
-    val isParentPostInThread = joinedItemType == PostItemViewJoinedType.PARENT
     val isSaved = post?.isSaved == true
 
     val cardColor = when {
-        isParentPostInThread -> MaterialTheme.colorScheme.background
         isResolving -> PostColors.StatusBackground.resolving
         isPinned -> PostColors.StatusBackground.pinned
         isSaved -> PostColors.StatusBackground.saved
-        else -> CardDefaults.cardColors().containerColor
+        else -> MaterialTheme.colorScheme.background
     }
 
     val cardShape: Shape = when (joinedItemType) {


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
Message background should be removed to align web.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Removed the background from message.

### Steps for testing
Communication enabled course

1. Open communication channel, and wrote messages.
2. Verify that gray background is not there.
3. Special case background like (pin, saved) should be remain  the same

### Screenshots

<img width="525" alt="Screenshot 2025-05-09 at 20 49 53" src="https://github.com/user-attachments/assets/4c6d80e6-e480-4c73-b84d-0506cae98ab5" />
