### PR TITLE
`Bugfix`: Show correct user role badge after sending message

### DIFF
--- a/feature/metis/conversation/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/shared/ui/post/PostMainContent.kt
+++ b/feature/metis/conversation/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/shared/ui/post/PostMainContent.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -53,7 +52,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.d
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.IBasePost
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.IStandalonePost
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.UserRole
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.common.UserRoleBadge
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.common.OptionalUserRoleBadge
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.profile_picture.ProfilePictureWithDialog
 import io.github.fornewid.placeholder.material3.placeholder
 import kotlinx.coroutines.delay
@@ -315,15 +314,9 @@ private fun AuthorRoleAndTimeRow(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
-
-            /*
-            * remember is needed here to prevent the value from being reset after an update
-            * (the author role is not sent when updating a post)
-            */
-            val initialAuthorRole by remember { mutableStateOf(authorRole) }
-            UserRoleBadge(
+            OptionalUserRoleBadge(
                 modifier = Modifier.applyGrayscale(isGrayscale),
-                userRole = initialAuthorRole
+                userRole = authorRole
             )
 
             Spacer(modifier = Modifier.weight(1f))

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceImpl.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceImpl.kt
@@ -75,7 +75,7 @@ internal class MetisStorageServiceImpl(
                 authorId = author?.id ?: return null,
                 creationDate = creationDate,
                 content = content,
-                authorRole = authorRole?.asDb ?: UserRole.USER,
+                authorRole = authorRole?.asDb,
                 updatedDate = updatedDate,
                 isSaved = isSaved,
                 hasForwardedMessages = hasForwardedMessages
@@ -107,7 +107,7 @@ internal class MetisStorageServiceImpl(
                 authorId = authorId ?: return null,
                 creationDate = creationDate ?: Instant.fromEpochSeconds(0),
                 content = content,
-                authorRole = authorRole?.asDb ?: UserRole.USER,
+                authorRole = authorRole?.asDb,
                 updatedDate = updatedDate,
                 isSaved = isSaved,
                 hasForwardedMessages = hasForwardedMessages
@@ -565,7 +565,9 @@ internal class MetisStorageServiceImpl(
         metisContext: MetisContext,
         answerPostId: Long?
     ) {
-        val authorRole = (if (isNewPost && answerPost.authorRole == null) {
+        // TODO: change below maybe already enough.
+        // TODO: if yes, undo the nullable authorRole changes in the pojos
+        val authorRole = (if (answerPost.authorRole == null) {
             metisDao.queryPostAuthorRole(answerPostClientSidePostId)
         } else answerPost.authorRole?.asDb)?.asNetwork
 

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/AnswerPost.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/content/dto/AnswerPost.kt
@@ -29,6 +29,7 @@ data class AnswerPost(
     constructor(answerPostDb: AnswerPostPojo, post: StandalonePost) : this(
         id = answerPostDb.serverPostId,
         author = User(id = answerPostDb.authorId),
+        authorRole = answerPostDb.authorRole,
         content = answerPostDb.content,
         creationDate = answerPostDb.creationDate,
         post = post

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/db/MetisDao.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/db/MetisDao.kt
@@ -338,7 +338,7 @@ interface MetisDao {
     ): Int
 
     @Query("select author_role from postings where id = :clientPostId")
-    suspend fun queryPostAuthorRole(clientPostId: String): UserRole
+    suspend fun queryPostAuthorRole(clientPostId: String): UserRole?
 
     @Query("select server_post_id from metis_post_context where server_id = :serverId and client_post_id = :clientPostId")
     suspend fun queryServerSidePostId(serverId: String, clientPostId: String): Long

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/db/pojo/AnswerPostPojo.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/db/pojo/AnswerPostPojo.kt
@@ -57,7 +57,7 @@ data class AnswerPostPojo(
     override val content: String? = basePostingCache.content
 
     @Ignore
-    override val authorRole: UserRole = basePostingCache.authorRole
+    override val authorRole: UserRole? = basePostingCache.authorRole
 
     @Ignore
     override val authorName: String = basePostingCache.authorName
@@ -98,7 +98,7 @@ data class AnswerPostPojo(
         @ColumnInfo(name = "content")
         val content: String?,
         @ColumnInfo(name = "author_role")
-        val authorRole: UserRole,
+        val authorRole: UserRole?,
         @Relation(
             entity = MetisUserEntity::class,
             entityColumn = "id",

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/db/pojo/PostPojo.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/db/pojo/PostPojo.kt
@@ -28,7 +28,7 @@ data class PostPojo(
     @ColumnInfo(name = "author_name")
     override val authorName: String,
     @ColumnInfo(name = "author_role")
-    override val authorRole: UserRole,
+    override val authorRole: UserRole?,
     @ColumnInfo(name = "author_id")
     override val authorId: Long,
     @ColumnInfo(name = "author_image_url")

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ui/common/UserRoleBadge.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ui/common/UserRoleBadge.kt
@@ -68,11 +68,23 @@ private fun UserRoleBadgesRow(
     }
 }
 
+@Composable
+fun OptionalUserRoleBadge(
+    modifier: Modifier = Modifier,
+    userRole: UserRole?
+) {
+    if (userRole != null) {
+        UserRoleBadge(
+            modifier = modifier,
+            userRole = userRole
+        )
+    }
+}
 
 @Composable
 fun UserRoleBadge(
     modifier: Modifier = Modifier,
-    userRole: UserRole?
+    userRole: UserRole
 ) {
     UserRoleBadge(
         modifier = modifier,

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ui/profile_picture/UserProfileDialog.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/ui/profile_picture/UserProfileDialog.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.UserRole
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.common.UserRoleBadge
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.common.OptionalUserRoleBadge
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.visiblemetiscontextreporter.LocalVisibleMetisContextManager
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -149,7 +149,7 @@ private fun UserProfileDialogHeader(
         Column(
             modifier = Modifier.padding(start = 16.dp),
         ) {
-            UserRoleBadge(
+            OptionalUserRoleBadge(
                 userRole = userRole,
             )
 


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
There was an issue that the user role badge as a tutor sometimes was stuck on displaying "Student" even though the user is a "Tutor". After reloading the issue was gone. See https://github.com/ls1intum/Artemis/issues/10824

Additionally, the role badge shortly showed "Student" when sending a message, then it switched back to the correct author role.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Fixed by removing the `remember` statement of the authorRole. Instead we handle remembering the author role for updates now in the database.
Additionally, I made the userRole nullable, so that we do not display any role badge when the role is null (instead of displaying "Student")


### Steps for testing
1. Login as a tutor (or instructor)
2. Go to any chat
3. Write a post
4. See that author role badge is shown correctly
5. Also test for creating answer posts and editing posts

### Screenshots

https://github.com/user-attachments/assets/fa0a1ffe-1543-4dad-8479-16bd65c8f557

