### PR TITLE
`Improvement`: Show more information in empty lists

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/DataStateUi.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/DataStateUi.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SignalWifiOff
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -22,6 +24,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import de.tum.informatics.www1.artemis.native_app.core.data.DataState
 import de.tum.informatics.www1.artemis.native_app.core.ui.R
+import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 
 
 /**
@@ -100,19 +103,19 @@ inline fun <T> Content(
             Column(
                 modifier = Modifier
             ) {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = failureText,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.bodyLarge,
+                EmptyListHint(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = Spacings.ScreenHorizontalSpacing)
+                        .align(Alignment.CenterHorizontally),
+                    hint = failureText,
+                    imageVector = Icons.Outlined.SignalWifiOff
                 )
 
                 TextButton(
                     onClick = onClickRetry,
                     content = { Text(text = retryButtonText) },
-                    modifier = Modifier
-                        .padding(top = 0.dp)
-                        .align(Alignment.CenterHorizontally)
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
             }
         }

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/EmptyListHint.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/EmptyListHint.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 fun EmptyListHint(
     modifier: Modifier,
     hint: String,
+    secondaryHint: String? = null,
     imageVector: ImageVector? = null,
     painter: Painter? = null
 ) {
@@ -62,6 +63,17 @@ fun EmptyListHint(
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+
+        Spacer(modifier = Modifier.size(4.dp))
+
+        secondaryHint?.let {
+            Text(
+                text = secondaryHint,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/feature/course-registration/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseregistration/RegisterForCourseUi.kt
+++ b/feature/course-registration/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseregistration/RegisterForCourseUi.kt
@@ -1,7 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.feature.courseregistration
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -31,11 +30,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
@@ -44,6 +42,7 @@ import de.tum.informatics.www1.artemis.native_app.core.model.Course
 import de.tum.informatics.www1.artemis.native_app.core.ui.AwaitDeferredCompletion
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.BasicDataStateUi
+import de.tum.informatics.www1.artemis.native_app.core.ui.common.EmptyListHint
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.course.CourseItemPreview
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.course.util.CourseUtil
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.NavigationBackButton
@@ -184,16 +183,14 @@ private fun RegisterForCourseContent(
         val columnCount = CourseUtil.computeCourseColumnCount(windowSizeClass)
 
         if(data.isEmpty()) {
-            Column(
-                modifier = Modifier.align(Alignment.Center)
-            ) {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(id = R.string.course_registration_no_courses),
-                    textAlign = TextAlign.Center,
-                    fontSize = 18.sp
-                )
-            }
+            EmptyListHint(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacings.ScreenHorizontalSpacing)
+                    .align(Alignment.Center),
+                hint = stringResource(id = R.string.course_registration_no_courses),
+                painter =  painterResource(id = de.tum.informatics.www1.artemis.native_app.core.ui.R.drawable.enroll)
+            )
         }
 
         LazyVerticalGrid(

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisChatList.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/chatlist/MetisChatList.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +36,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
+import de.tum.informatics.www1.artemis.native_app.core.ui.common.EmptyListHint
 import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.ProvideMarkwon
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.emoji_picker.service.EmojiService
@@ -189,7 +192,15 @@ fun MetisChatList(
             ) {
                 when (posts) {
                     PostsDataState.Empty -> {
-                        NoPostsFoundInformation(modifier = informationModifier)
+                        EmptyListHint(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = Spacings.ScreenHorizontalSpacing)
+                                .align(Alignment.Center),
+                            hint = stringResource(id = R.string.metis_post_list_empty),
+                            secondaryHint = stringResource(id = R.string.metis_post_list_empty_secondary),
+                            imageVector = Icons.AutoMirrored.Filled.Chat,
+                        )
                     }
 
                     PostsDataState.Loading -> {
@@ -420,22 +431,6 @@ private fun LoadingPostsInformation(modifier: Modifier) {
 
         LinearProgressIndicator(
             modifier = Modifier.fillMaxWidth(0.4f)
-        )
-    }
-}
-
-@Composable
-private fun NoPostsFoundInformation(
-    modifier: Modifier
-) {
-    Box(
-        modifier = modifier,
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = stringResource(id = R.string.metis_post_list_empty),
-            style = MaterialTheme.typography.bodyLarge,
-            textAlign = TextAlign.Center
         )
     }
 }

--- a/feature/metis/conversation/src/main/res/values/conversation_strings.xml
+++ b/feature/metis/conversation/src/main/res/values/conversation_strings.xml
@@ -27,7 +27,8 @@
     <string name="course_wide_context_random">Random</string>
     <string name="course_wide_context_announcement">Announcement</string>
 
-    <string name="metis_post_list_empty">No posts found.</string>
+    <string name="metis_post_list_empty">No messages found</string>
+    <string name="metis_post_list_empty_secondary">Write the first message to kickstart this conversation.</string>
     <string name="metis_post_list_loading">Loading posts…</string>
     <string name="metis_post_list_error">Something went wrong while loading your posts.</string>
     <string name="metis_post_list_error_try_again">Try again</string>


### PR DESCRIPTION
### Problem Description

As described in #319 there a lists that do not contain any information when they are empty. 

### Changes

Although most of the lists already have an empty list view, that provides information if a list is empty this PR adds the empty list hints for the remaining views that do not have such a hint yet.
This PR closes #319 

### Steps for testing

1. Verify that when there is no internet an icon is now shown.
2. Verify that all lists have an icon and a text when they are empty.

### Screenshots
![image](https://github.com/user-attachments/assets/68c3016c-0a58-4d65-b67c-b87f66752d81)
