### PR TITLE
`Bugfix`: Fix navigation after clicking on chat push notification

### DIFF
--- a/feature/course-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseview/ui/course_overview/CourseUiScreen.kt
+++ b/feature/course-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseview/ui/course_overview/CourseUiScreen.kt
@@ -424,19 +424,28 @@ private fun getInitialConversationConfiguration(
     username: String?,
     userId: Long?
 ): ConversationConfiguration = when {
-    conversationId != null && postId != null -> OpenedConversation(
-        _prevConfiguration = IgnoreCustomBackHandling,
-        conversationId = conversationId,
-        openedThread = OpenedThread(
-            StandalonePostId.ServerSideId(postId)
+    conversationId != null -> {
+        val chatConfig = OpenedConversation(
+            _prevConfiguration = IgnoreCustomBackHandling,
+            conversationId = conversationId,
+            openedThread = null
         )
-    )
 
-    conversationId != null -> OpenedConversation(
-        _prevConfiguration = IgnoreCustomBackHandling,
-        conversationId = conversationId,
-        openedThread = null
-    )
+        if (postId == null) {
+            chatConfig
+        } else {
+            // Currently, we only end up in this case when the user clicks on a notification.
+            // In this case, we want to setup the prevConfiguration to be mirror the behavior of
+            // manually opening the post thread, so that the back navigation works as expected.
+            OpenedConversation(
+                _prevConfiguration = chatConfig.copy(_prevConfiguration = NothingOpened),
+                conversationId = conversationId,
+                openedThread = OpenedThread(
+                    StandalonePostId.ServerSideId(postId)
+                )
+            )
+        }
+    }
 
     username != null -> NavigateToUserConversation(
         _prevConfiguration = IgnoreCustomBackHandling,

--- a/feature/course-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseview/ui/course_overview/CourseUiScreen.kt
+++ b/feature/course-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseview/ui/course_overview/CourseUiScreen.kt
@@ -331,7 +331,7 @@ internal fun CourseUiScreen(
                                 )
                             }
                         ),
-                        title = courseName ?: ""
+                        title = courseName
                     )
                 }
             }
@@ -348,7 +348,7 @@ internal fun CourseUiScreen(
                         collapsingContentState = collapsingContentState,
                         onViewExercise = onNavigateToExercise,
                         onNavigateToLectureScreen = { id -> onNavigateToLecture(id ?: 0L) },
-                        title = courseName ?: ""
+                        title = courseName
                     )
                 }
             }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
When clicking on a push notification, the user was navigated to the post thread, but when clicking the back button, the user was taken back to the course dashboard. 

This PR closes #615 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Handle the notification deeplink to setup the navigation with the chat and conversation overview screen.

### Steps for testing
- Enable push notifications on the emulator
- Send a message to the emulator user with another user,  eg from the webapp
- Receive a communication push notification
- Click on it
- See the thread with the post opening
- Navigate back -> see the chat
- Navigate back again -> see conversations overview
- Verify that the other navigations have not been affected by this change (eg navigating to a savedPost and back)

### Screenshots

https://github.com/user-attachments/assets/d7a5f6fa-c5d1-4313-94f1-1f91f59a696a

