### PR TITLE
`Improvement`:  Fix conversation list state

### DIFF
--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationOverviewViewModel.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/overview/ConversationOverviewViewModel.kt
@@ -144,6 +144,9 @@ class ConversationOverviewViewModel(
         MutableStateFlow<ConversationOverviewUtils.ConversationFilter>(ConversationOverviewUtils.ConversationFilter.All)
     val currentFilter: StateFlow<ConversationOverviewUtils.ConversationFilter> = _currentFilter
 
+    private val _scrollPosition = MutableStateFlow(0)
+    val scrollPosition: StateFlow<Int> = _scrollPosition
+
     private val conversationUpdates: Flow<ConversationWebsocketDto> = clientId
         .filterSuccess()
         .flatMapLatest { userId ->
@@ -621,4 +624,8 @@ class ConversationOverviewViewModel(
         isExpanded: Boolean,
         showPrefix: Boolean = true
     ) = ConversationCollection(this, isExpanded, showPrefix)
+
+    fun saveScrollPosition(position: Int) {
+        _scrollPosition.value = position
+    }
 }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
On click to a channel and go back user go back to start of the list.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Store the list position and display list accordingly

### Steps for testing
Open conversation enabled course
Scroll to a channel
Verify on click to channel and back return scroll state remain the same.

### Screenshots

Uploading Screen Recording 2025-05-21 at 15.09.40.mov…

