### PR TITLE
`Chore`: Add workaround for robolectric bug

### DIFF
--- a/core/ui-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/test/BottomSheetClickWorkaroundTheme.kt
+++ b/core/ui-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/test/BottomSheetClickWorkaroundTheme.kt
@@ -1,0 +1,26 @@
+package de.tum.informatics.www1.artemis.native_app.core.ui.test
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+
+// There is a bug in robolectric that makes content within a composable with rounded corners not clickable anymore.
+// This is a workaround to make tests affected by this pass again.
+// From: https://github.com/robolectric/robolectric/issues/9595#issuecomment-2851919271
+@Composable
+fun BottomSheetClickWorkaroundTheme(
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(
+        shapes = Shapes(
+            extraSmall = RoundedCornerShape(0.dp),
+            small = RoundedCornerShape(0.dp),
+            medium = RoundedCornerShape(0.dp),
+            large = RoundedCornerShape(0.dp),
+            extraLarge = RoundedCornerShape(0.dp)
+        ),
+        content = content,
+    )
+}

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/LocalSegmentedButtonBaseShapeProvider.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/LocalSegmentedButtonBaseShapeProvider.kt
@@ -1,0 +1,40 @@
+package de.tum.informatics.www1.artemis.native_app.core.ui
+
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.unit.dp
+
+// There is a bug in robolectric that makes content within a composable with rounded corners not clickable anymore.
+// See: https://github.com/robolectric/robolectric/issues/9595#issuecomment-2851919271
+// This issue also applies to SegmentedButtons, but they do no use the MaterialTheme shapes, so we can not use the
+// BottomSheetClickWorkaroundTheme workaround.
+
+val LocalSegmentedButtonBaseShapeProvider = compositionLocalOf<SegmentedButtonBaseShapeProvider> {
+    DefaultSegmentedButtonBaseShapeProvider
+}
+
+interface SegmentedButtonBaseShapeProvider {
+    @Composable
+    fun getBaseShape(): CornerBasedShape
+}
+
+object DefaultSegmentedButtonBaseShapeProvider : SegmentedButtonBaseShapeProvider {
+    @Composable
+    override fun getBaseShape(): CornerBasedShape = SegmentedButtonDefaults.baseShape
+}
+
+object TestSegmentedButtonBaseShapeProvider : SegmentedButtonBaseShapeProvider {
+    @Composable
+    override fun getBaseShape(): CornerBasedShape = SegmentedButtonDefaults.baseShape.copy(
+        topStart = CornerSize(0.dp),
+        topEnd = CornerSize(0.dp),
+        bottomStart = CornerSize(0.dp),
+        bottomEnd = CornerSize(0.dp),
+    )
+}
+
+
+

--- a/feature/metis/conversation/saved-posts/src/test/java/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/saved_posts/SavedPostsScreenUiTest.kt
+++ b/feature/metis/conversation/saved-posts/src/test/java/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/saved_posts/SavedPostsScreenUiTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
 import de.tum.informatics.www1.artemis.native_app.core.data.DataState
 import de.tum.informatics.www1.artemis.native_app.core.test.BaseComposeTest
+import de.tum.informatics.www1.artemis.native_app.core.ui.test.BottomSheetClickWorkaroundTheme
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.saved_posts.ui.SavedPostsScreen
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.shared.service.MetisModificationFailure
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.shared.ui.ChatListItem
@@ -19,7 +20,6 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.getStr
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
@@ -72,9 +72,6 @@ class SavedPostsScreenUiTest : BaseComposeTest() {
             .assertExists()
     }
 
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
     @Test
     fun `test GIVEN a single Saved Post WHEN pressing 'Remove from saved' THEN the callback is called`() {
         var removeCalled = false
@@ -107,15 +104,23 @@ class SavedPostsScreenUiTest : BaseComposeTest() {
         onRemoveFromSavedPosts: (ISavedPost) -> Deferred<MetisModificationFailure?> = { CompletableDeferred() }
     ) {
         composeTestRule.setContent {
-            SavedPostsScreen(
-                modifier = Modifier,
-                savedPostsChatListItemsDataState = DataState.Success(listOf(ChatListItem.PostItem.SavedItem.SavedPost(savedPost))),
-                onRequestReload = {},
-                onNavigateToPost = { _ -> },
-                onChangeStatus = onChangeStatus,
-                onRemoveFromSavedPosts = onRemoveFromSavedPosts,
-                onSidebarToggle = {}
-            )
+            BottomSheetClickWorkaroundTheme {
+                SavedPostsScreen(
+                    modifier = Modifier,
+                    savedPostsChatListItemsDataState = DataState.Success(
+                        listOf(
+                            ChatListItem.PostItem.SavedItem.SavedPost(
+                                savedPost
+                            )
+                        )
+                    ),
+                    onRequestReload = {},
+                    onNavigateToPost = { _ -> },
+                    onChangeStatus = onChangeStatus,
+                    onRemoveFromSavedPosts = onRemoveFromSavedPosts,
+                    onSidebarToggle = {}
+                )
+            }
         }
     }
 

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ConversationAnswerMessagesUITest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ConversationAnswerMessagesUITest.kt
@@ -13,8 +13,8 @@ import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.thread.TEST_TAG_THREAD_LIST
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.IBasePost
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.db.pojo.AnswerPostPojo
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.db.pojo.PostPojo
 import kotlinx.coroutines.CompletableDeferred
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
@@ -22,9 +22,6 @@ import org.robolectric.RobolectricTestRunner
 
 @Category(UnitTest::class)
 @RunWith(RobolectricTestRunner::class)
-@Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-        "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-        "https://github.com/robolectric/robolectric/issues/9595")
 class ConversationAnswerMessagesUITest : BaseChatUITest() {
 
     private fun testTagForAnswerPost(answerPostId: String) = "answerPost$answerPostId"
@@ -33,57 +30,18 @@ class ConversationAnswerMessagesUITest : BaseChatUITest() {
 
     @Test
     fun `test GIVEN post is not resolved WHEN resolving the post THEN the post is resolved with the first answer post`() {
-        var resolvedPost: IBasePost? = null
-
-        setupThreadUi(
-            post = post,
-            onResolvePost = { post ->
-                resolvedPost = post
-                CompletableDeferred()
-            }
-        )
-
-        composeTestRule.onNodeWithText(answers[0].content!!, useUnmergedTree = true)
-            .performSemanticsAction(SemanticsActions.OnLongClick)
-        composeTestRule.onNodeWithText(context.getString(R.string.post_resolves))
-            .performClick()
-
-        assert(resolvedPost != null)
-        assert(resolvedPost is AnswerPostPojo)
-        assert((resolvedPost as AnswerPostPojo).content == answers[0].content!!)
+        markAnswerAsResolvingImpl(0)
     }
 
     @Test
     fun `test GIVEN post is not resolved WHEN resolving the post THEN the post is resolved with the third answer post`() {
-        var resolvedPost: IBasePost? = null
-
-        setupThreadUi(
-            post = post,
-            onResolvePost = { post ->
-                resolvedPost = post
-                CompletableDeferred()
-            }
-        )
-
-        composeTestRule.onNodeWithText(answers[2].content!!, useUnmergedTree = true)
-            .performSemanticsAction(SemanticsActions.OnLongClick)
-        composeTestRule.onNodeWithText(context.getString(R.string.post_resolves)).performClick()
-
-        assert(resolvedPost != null)
-        assert(resolvedPost is AnswerPostPojo)
-        assert((resolvedPost as AnswerPostPojo).content == answers[2].content!!)
+        markAnswerAsResolvingImpl(2)
     }
 
     @Test
     fun `test GIVEN post is resolved WHEN un-resolving the post THEN the post is un-resolved`() {
         val resolvingIndex = 0
-
-        val modifiedAnswers = answers.toMutableList()
-        modifiedAnswers[resolvingIndex] = modifiedAnswers[resolvingIndex].copy(resolvesPost = true)
-        val resolvedPost = post.copy(
-            resolved = true,
-            answers = modifiedAnswers
-        )
+        val resolvedPost = createResolvedPost(resolvingIndex)
 
         var unresolvedPost: IBasePost? = null
 
@@ -110,38 +68,71 @@ class ConversationAnswerMessagesUITest : BaseChatUITest() {
         setupThreadUi(post)
 
         composeTestRule.onNodeWithText(post.content).assertExists()
-        for (answer in answers) {
-            composeTestRule.onNodeWithText(answer.content!!).assertExists()
-        }
         composeTestRule.onNodeWithText(context.getString(R.string.post_is_resolved))
             .assertDoesNotExist()
-        composeTestRule.onNodeWithText(context.getString(R.string.post_resolves))
-            .assertDoesNotExist()
+
+        for ((index, answer) in answers.withIndex()) {
+            scrollToAnswerPostIndex(index)
+            composeTestRule.onNodeWithText(answer.content!!).assertExists()
+            composeTestRule.onNodeWithText(context.getString(R.string.post_resolves))
+                .assertDoesNotExist()
+        }
     }
 
     @Test
     fun `test GIVEN the post is resolved and one answer post is marked as resolving THEN the post is shown as resolved and this answer post is shown as resolving`() {
-        val resolvingIndex = 0
+        val resolvingIndex = 2
 
-        val modifiedAnswers = answers.toMutableList()
-        modifiedAnswers[resolvingIndex] = modifiedAnswers[resolvingIndex].copy(resolvesPost = true)
-        val resolvedPost = post.copy(
-            resolved = true,
-            answers = modifiedAnswers
-        )
+        val resolvedPost = createResolvedPost(resolvingIndex)
 
         setupThreadUi(resolvedPost)
 
         val resolvesAssertion = hasAnyChild(hasText(context.getString(R.string.post_resolves)))
 
         for (i in answers.indices) {
-            composeTestRule
-                .onNodeWithTag(TEST_TAG_THREAD_LIST, useUnmergedTree = true)
-                .performScrollToIndex(i)
+            scrollToAnswerPostIndex(i)
 
             composeTestRule
-                .onNodeWithTag(testTagForAnswerPost(answers[i].postId), useUnmergedTree = true)
+                .onNodeWithTag(testTagForAnswerPost(answers[i].postId))
                 .assert(if (i == resolvingIndex) resolvesAssertion else resolvesAssertion.not())
         }
+    }
+
+    private fun createResolvedPost(resolvingIndex: Int): PostPojo {
+        val modifiedAnswers = answers.toMutableList()
+        modifiedAnswers[resolvingIndex] = modifiedAnswers[resolvingIndex].copy(resolvesPost = true)
+        val resolvedPost = post.copy(
+            resolved = true,
+            answers = modifiedAnswers
+        )
+        return resolvedPost
+    }
+
+
+    private fun markAnswerAsResolvingImpl(index: Int) {
+        var resolvedPost: IBasePost? = null
+
+        setupThreadUi(
+            post = post,
+            onResolvePost = { post ->
+                resolvedPost = post
+                CompletableDeferred()
+            }
+        )
+
+        scrollToAnswerPostIndex(index)
+        composeTestRule.onNodeWithText(answers[index].content!!, useUnmergedTree = true)
+            .performSemanticsAction(SemanticsActions.OnLongClick)
+        composeTestRule.onNodeWithText(context.getString(R.string.post_resolves)).performClick()
+
+        assert(resolvedPost != null)
+        assert(resolvedPost is AnswerPostPojo)
+        assert((resolvedPost as AnswerPostPojo).content == answers[index].content!!)
+    }
+
+    private fun scrollToAnswerPostIndex(index: Int) {
+        composeTestRule
+            .onNodeWithTag(TEST_TAG_THREAD_LIST, useUnmergedTree = true)
+            .performScrollToIndex(index)
     }
 }

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ConversationMessagesUITest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ConversationMessagesUITest.kt
@@ -10,12 +10,10 @@ import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.shared.ui.post.TEST_TAG_DELETED_FORWARDED_POST
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.shared.ui.post.TEST_TAG_FORWARDED_POST_COLUMN
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.shared.ui.post.testTagForForwardedPost
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.StandalonePostId
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.DisplayPriority
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.IBasePost
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.db.pojo.PostPojo
 import kotlinx.coroutines.CompletableDeferred
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
@@ -25,114 +23,28 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ConversationMessagesUITest : BaseChatUITest() {
 
-    private fun testTagForPost(postId: StandalonePostId?) = "post$postId"
-
     // ################################# PIN VISIBILITY TESTS #####################################
 
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
     @Test
     fun `test GIVEN post is not pinned WHEN pinning the post THEN the correct post gets pinned`() {
-        var changedPost: IBasePost? = null
-
-        setupChatUi(posts = posts, onPinPost =  { post ->
-            changedPost = post
-            CompletableDeferred()
-        })
-
-        composeTestRule.onNodeWithTag(
-            testTagForPost(posts[0].standalonePostId),
-            useUnmergedTree = true
-        )
-            .performSemanticsAction(SemanticsActions.OnLongClick)
-        composeTestRule.onNodeWithText(context.getString(R.string.post_pin))
-            .performClick()
-
-        testPinDestination(changedPost)
+        testPostPinningCallback()
     }
-
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
+    
     @Test
     fun `test GIVEN post is pinned WHEN unpinning the post THEN the correct post gets unpinned`() {
-        var changedPost: IBasePost? = null
-        val modifiedPosts = posts.toMutableList()
-        modifiedPosts[0] = modifiedPosts[0].copy(displayPriority = DisplayPriority.PINNED)
-
-        setupChatUi(posts = modifiedPosts, onPinPost =  { post ->
-            changedPost = post
-            CompletableDeferred()
-        })
-
-        composeTestRule.onNodeWithTag(
-            testTagForPost(posts[0].standalonePostId),
-            useUnmergedTree = true
-        )
-            .performSemanticsAction(SemanticsActions.OnLongClick)
-        composeTestRule.onNodeWithText(context.getString(R.string.post_unpin))
-            .performClick()
-
-        testPinDestination(changedPost)
+        testPostPinningCallback(unpin = true)
     }
 
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
     @Test
     fun `test GIVEN post is not pinned in thread WHEN pinning the post THEN the correct post gets pinned in thread`() {
-        var changedPost: IBasePost? = null
-
-        setupThreadUi(
-            post = posts[0],
-            onPinPost = { post ->
-                changedPost = post
-                CompletableDeferred()
-            }
-        )
-
-        composeTestRule.onNodeWithTag(
-            testTagForPost(posts[0].standalonePostId),
-            useUnmergedTree = true
-        )
-            .performSemanticsAction(SemanticsActions.OnLongClick)
-        composeTestRule.onNodeWithText(context.getString(R.string.post_pin))
-            .performClick()
-
-        testPinDestination(changedPost)
+        testPostPinningCallback(inThread = true)
     }
 
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
     @Test
     fun `test GIVEN post is pinned in thread WHEN unpinning the post THEN the correct post gets unpinned in thread`() {
-        var changedPost: IBasePost? = null
-        val modifiedPosts = posts.toMutableList()
-        modifiedPosts[0] = modifiedPosts[0].copy(displayPriority = DisplayPriority.PINNED)
-
-        setupThreadUi(
-            post = modifiedPosts[0],
-            onPinPost = { post ->
-                changedPost = post
-                CompletableDeferred()
-            })
-
-        composeTestRule.onNodeWithTag(
-            testTagForPost(posts[0].standalonePostId),
-            useUnmergedTree = true
-        )
-            .performSemanticsAction(SemanticsActions.OnLongClick)
-        composeTestRule.onNodeWithText(context.getString(R.string.post_unpin))
-            .performClick()
-
-        testPinDestination(changedPost)
+        testPostPinningCallback(inThread = true, unpin = true)
     }
 
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
     @Test
     fun `test GIVEN the post is not pinned THEN the post is not shown as pinned`() {
         setupChatUi(posts)
@@ -140,9 +52,6 @@ class ConversationMessagesUITest : BaseChatUITest() {
         testPinnedLabelInvisibility()
     }
 
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
     @Test
     fun `test GIVEN the post is not pinned in thread THEN the post is not shown as pinned in thread`() {
         setupThreadUi(posts[0])
@@ -150,9 +59,6 @@ class ConversationMessagesUITest : BaseChatUITest() {
         testPinnedLabelInvisibility()
     }
 
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
     @Test
     fun `test GIVEN the post is pinned THEN the post is shown as pinned`() {
         val modifiedPosts = posts.toMutableList()
@@ -162,9 +68,6 @@ class ConversationMessagesUITest : BaseChatUITest() {
         testPinnedLabelVisibility()
     }
 
-    @Ignore("There is an open issue about onClick events not working for the ModalBottomSheetLayout with" +
-            "the robolectric test runner. Enable this test again as soon as the following issue is resolved:" +
-            "https://github.com/robolectric/robolectric/issues/9595")
     @Test
     fun `test GIVEN the post is pinned in thread THEN the post is shown as pinned in thread`() {
         setupThreadUi(posts[0].copy(displayPriority = DisplayPriority.PINNED))
@@ -226,6 +129,50 @@ class ConversationMessagesUITest : BaseChatUITest() {
             useUnmergedTree = true
         )
             .assertExists()
+    }
+
+    private fun testPostPinningCallback(
+        inThread: Boolean = false,
+        unpin: Boolean = false,
+    ) {
+        var changedPost: IBasePost? = null
+
+        val posts = posts.toMutableList()
+        if (unpin) {
+            posts[0] = posts[0].copy(displayPriority = DisplayPriority.PINNED)
+        }
+
+        if (inThread) {
+            setupThreadUi(
+                post = posts[0],
+                isAbleToPin = true,
+                onPinPost = { post ->
+                    changedPost = post
+                    CompletableDeferred()
+                }
+            )
+        } else {
+            setupChatUi(
+                posts = posts,
+                isAbleToPin = true,
+                onPinPost = { post ->
+                    changedPost = post
+                    CompletableDeferred()
+                }
+            )
+        }
+
+        composeTestRule.onNodeWithText(
+            this.posts[0].content,
+            useUnmergedTree = true
+        )
+            .performSemanticsAction(SemanticsActions.OnLongClick)
+
+        val text = if (unpin) context.getString(R.string.post_unpin) else context.getString(R.string.post_pin)
+        composeTestRule.onNodeWithText(text)
+            .performClick()
+
+        testPinDestination(changedPost)
     }
 
     private fun testPinnedLabelInvisibility() {

--- a/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextFieldVisibilityUITest.kt
+++ b/feature/metis/conversation/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/reply/ReplyTextFieldVisibilityUITest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.performClick
 import de.tum.informatics.www1.artemis.native_app.core.common.test.UnitTest
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.BaseChatUITest
 import junit.framework.TestCase.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
@@ -16,14 +15,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class ReplyTextFieldVisibilityUITest : BaseChatUITest() {
 
-    @Ignore("This test does not work anymore, see https://github.com/ls1intum/artemis-android/issues/495")
     @Test
     fun `test GIVEN the thread view is shown containing one post and three answer posts WHEN the markdown text field is clicked THEN the keyboard is shown below the markdown text field`() {
         setupThreadUi(posts[0])
         runTest()
     }
 
-    @Ignore("This test does not work anymore, see https://github.com/ls1intum/artemis-android/issues/495")
     @Test
     fun `test GIVEN the chat list containing three posts is shown WHEN the markdown text field is clicked THEN the keyboard is shown below the markdown text field`() {
         setupChatUi(posts)

--- a/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/create_channel/CreateChannelScreen.kt
+++ b/feature/metis/manage-conversations/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/ui/conversation/create_channel/CreateChannelScreen.kt
@@ -41,13 +41,13 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import de.tum.informatics.www1.artemis.native_app.core.ui.LocalSegmentedButtonBaseShapeProvider
 import de.tum.informatics.www1.artemis.native_app.core.ui.Scaling
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.ArtemisSection
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.AdaptiveNavigationIcon
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.ArtemisTopAppBar
-import de.tum.informatics.www1.artemis.native_app.core.ui.compose.NavigationBackButton
 import de.tum.informatics.www1.artemis.native_app.core.ui.pagePadding
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.common.PotentiallyIllegalTextField
@@ -59,6 +59,14 @@ internal const val TEST_TAG_CREATE_CHANNEL_BUTTON = "create channel button"
 internal const val TEST_TAG_SET_PRIVATE_PUBLIC_SWITCH = "TEST_TAG_SET_PRIVATE_PUBLIC_SWITCH"
 internal const val TEST_TAG_SET_ANNOUNCEMENT_UNRESTRICTED_SWITCH = "TEST_TAG_SET_ANNOUNCEMENT_UNRESTRICTED_SWITCH"
 internal const val TEST_TAG_SET_COURSE_WIDE_SELECTIVE_SWITCH = "TEST_TAG_SET_COURSE_WIDE_SELECTIVE_SWITCH"
+
+internal fun getSegmentedSelectionTestTag(
+    testTag: String,
+    index: Int,
+    selected: Boolean
+): String {
+    return "$testTag$index$selected"
+}
 
 @Composable
 fun CreateChannelScreen(
@@ -273,6 +281,8 @@ private fun SegmentedSelection(
     onCheckedChange: (Int) -> Unit,
     testTag: String = ""
 ) {
+    val baseShapeProvider = LocalSegmentedButtonBaseShapeProvider.current
+
     Column(
         modifier = modifier.padding(bottom = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -297,7 +307,8 @@ private fun SegmentedSelection(
                 buttonLabelOption.forEachIndexed { index, label ->
                     val selected = index == selectedOption
                     SegmentedButton(
-                        modifier = Modifier.testTag(testTag + index + selected),
+                        modifier = Modifier
+                            .testTag(getSegmentedSelectionTestTag(testTag, index, selected)),
                         selected = selected,
                         colors = SegmentedButtonDefaults.colors(
                             inactiveContainerColor = CardDefaults.cardColors().containerColor,
@@ -307,7 +318,11 @@ private fun SegmentedSelection(
                         onClick = {
                             onCheckedChange(index)
                         },
-                        shape = SegmentedButtonDefaults.itemShape(index, buttonLabelOption.size),
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = buttonLabelOption.size,
+                            baseShape = baseShapeProvider.getBaseShape()
+                        ),
                         icon = {    // This had to be added manually to add padding to the icon
                             SegmentedButtonDefaults.Icon(
                                 active = selected,

--- a/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/overview/CreateChannelE2eTest.kt
+++ b/feature/metis/manage-conversations/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/manageconversations/overview/CreateChannelE2eTest.kt
@@ -1,12 +1,9 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.overview
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotSelected
-import androidx.compose.ui.test.assertIsOff
-import androidx.compose.ui.test.assertIsOn
-import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -17,6 +14,8 @@ import de.tum.informatics.www1.artemis.native_app.core.common.test.DefaultTestTi
 import de.tum.informatics.www1.artemis.native_app.core.common.test.EndToEndTest
 import de.tum.informatics.www1.artemis.native_app.core.common.test.testServerUrl
 import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.DefaultTimeoutMillis
+import de.tum.informatics.www1.artemis.native_app.core.ui.LocalSegmentedButtonBaseShapeProvider
+import de.tum.informatics.www1.artemis.native_app.core.ui.TestSegmentedButtonBaseShapeProvider
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_channel.CreateChannelScreen
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_channel.CreateChannelViewModel
@@ -24,11 +23,11 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversati
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_channel.TEST_TAG_SET_ANNOUNCEMENT_UNRESTRICTED_SWITCH
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_channel.TEST_TAG_SET_COURSE_WIDE_SELECTIVE_SWITCH
 import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_channel.TEST_TAG_SET_PRIVATE_PUBLIC_SWITCH
+import de.tum.informatics.www1.artemis.native_app.feature.metis.manageconversations.ui.conversation.create_channel.getSegmentedSelectionTestTag
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.service.network.getConversation
 import de.tum.informatics.www1.artemis.native_app.feature.metistest.ConversationBaseTest
 import kotlinx.coroutines.runBlocking
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
@@ -43,62 +42,49 @@ import kotlin.test.assertIs
 class CreateChannelE2eTest : ConversationBaseTest() {
 
     private val privateIndex = 1
-    private val courseWideIndex = 0
+    private val selectiveIndex = 1
 
-    @Ignore("This test does not work anymore, see https://github.com/ls1intum/artemis-android/issues/495")
     @Test(timeout = DefaultTestTimeoutMillis)
     fun `can create channel`() {
         canCreateChannelTestImpl(
             channelName = "testchannel1",
-            channelDescription = "testchannel description",
-            isPrivate = false,
-            isAnnouncement = true,
-            isCourseWide = false
+            channelDescription = "testchannel description"
         )
     }
 
-    @Ignore("This test does not work anymore, see https://github.com/ls1intum/artemis-android/issues/495")
     @Test(timeout = DefaultTestTimeoutMillis)
     fun `fun create channel without description`() {
         canCreateChannelTestImpl(
             channelName = "testchannel2",
-            channelDescription = "",
-            isPrivate = false,
-            isAnnouncement = true,
-            isCourseWide = false
+            channelDescription = ""
         )
     }
 
-    @Ignore("This test does not work anymore, see https://github.com/ls1intum/artemis-android/issues/495")
     @Test(timeout = DefaultTestTimeoutMillis)
-    fun `fun create private and unrestricted channel`() {
+    fun `fun create private and selective channel`() {
         canCreateChannelTestImpl(
             channelName = "testchannel3",
             channelDescription = "description",
             isPrivate = true,
-            isAnnouncement = false,
             isCourseWide = false
         )
     }
 
-    @Ignore("This test does not work anymore, see https://github.com/ls1intum/artemis-android/issues/495")
     @Test(timeout = DefaultTestTimeoutMillis)
-    fun `can create course-wide channel`() {
+    fun `can create announcement channel`() {
         canCreateChannelTestImpl(
             channelName = "testchannel4",
-            channelDescription = "Course-wide channel test",
-            isPrivate = false,
-            isAnnouncement = false,
-            isCourseWide = true
+            channelDescription = "Announcement channel test",
+            isAnnouncement = true,
         )
     }
 
     private fun canCreateChannelTestImpl(
         channelName: String,
         channelDescription: String,
-        isPrivate: Boolean,
-        isAnnouncement: Boolean,
-        isCourseWide: Boolean
+        isPrivate: Boolean = false,
+        isAnnouncement: Boolean = false,
+        isCourseWide: Boolean = true
     ) {
         Logger.info(
             "Testing create channel with properties: channelname=$channelName, channelDescription$channelDescription, isPublic=$isPrivate, isAnnouncement=$isAnnouncement, isCourseWide=$isCourseWide"
@@ -116,13 +102,17 @@ class CreateChannelE2eTest : ConversationBaseTest() {
         var createdConversationId: Long? = null
 
         composeTestRule.setContent {
-            CreateChannelScreen(
-                modifier = Modifier.fillMaxSize(),
-                viewModel = viewModel,
-                onConversationCreated = { createdConversationId = it },
-                onNavigateBack = {},
-                onSidebarToggle = {}
-            )
+            CompositionLocalProvider(
+                LocalSegmentedButtonBaseShapeProvider provides TestSegmentedButtonBaseShapeProvider
+            ) {
+                CreateChannelScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    viewModel = viewModel,
+                    onConversationCreated = { createdConversationId = it },
+                    onNavigateBack = {},
+                    onSidebarToggle = {}
+                )
+            }
         }
 
         composeTestRule
@@ -135,44 +125,44 @@ class CreateChannelE2eTest : ConversationBaseTest() {
             .performScrollTo()
             .performTextInput(channelDescription)
 
+        // Public/Private switch (default: private)
+        composeTestRule
+            .onNodeWithTag(TEST_TAG_SET_PRIVATE_PUBLIC_SWITCH)
+            .performScrollTo()
+
         if (isPrivate) {
             composeTestRule
-                .onNodeWithTag(TEST_TAG_SET_PRIVATE_PUBLIC_SWITCH)
-                .performScrollTo()
-            composeTestRule
-                .onNodeWithTag(TEST_TAG_SET_PRIVATE_PUBLIC_SWITCH + privateIndex)
-                .assertIsSelected()
-        } else {
-            composeTestRule
-                .onNodeWithTag(TEST_TAG_SET_PRIVATE_PUBLIC_SWITCH + privateIndex)
-                .assertIsNotSelected()
+                .onNodeWithTag(
+                    getSegmentedSelectionTestTag(
+                        testTag = TEST_TAG_SET_PRIVATE_PUBLIC_SWITCH,
+                        index = privateIndex,
+                        selected = false
+                    )
+                )
+                .performClick()
         }
 
+        // Course-wide/Selective switch (default: course-wide)
+        composeTestRule
+            .onNodeWithTag(TEST_TAG_SET_COURSE_WIDE_SELECTIVE_SWITCH)
+            .performScrollTo()
+
+        if (!isCourseWide) {
+            composeTestRule
+                .onNodeWithTag(getSegmentedSelectionTestTag(
+                    testTag = TEST_TAG_SET_COURSE_WIDE_SELECTIVE_SWITCH,
+                    index = selectiveIndex,
+                    selected = false
+                ))
+                .performClick()
+        }
+
+        // Announcement switch (default: false)
         if (isAnnouncement) {
             composeTestRule
                 .onNodeWithTag(TEST_TAG_SET_ANNOUNCEMENT_UNRESTRICTED_SWITCH)
                 .performScrollTo()
                 .performClick()
-            composeTestRule
-                .onNodeWithTag(TEST_TAG_SET_ANNOUNCEMENT_UNRESTRICTED_SWITCH)
-                .assertIsOn()
-        } else {
-            composeTestRule
-                .onNodeWithTag(TEST_TAG_SET_ANNOUNCEMENT_UNRESTRICTED_SWITCH)
-                .assertIsOff()
-        }
-
-        if (isCourseWide) {
-            composeTestRule
-                .onNodeWithTag(TEST_TAG_SET_COURSE_WIDE_SELECTIVE_SWITCH)
-                .performScrollTo()
-            composeTestRule
-                .onNodeWithTag(TEST_TAG_SET_COURSE_WIDE_SELECTIVE_SWITCH + courseWideIndex)
-                .assertIsSelected()
-        } else {
-            composeTestRule
-                .onNodeWithTag(TEST_TAG_SET_COURSE_WIDE_SELECTIVE_SWITCH + courseWideIndex)
-                .assertIsNotSelected()
         }
 
         composeTestRule


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
We had to disable many tests because of a bug in the robolectric testing framework. This bug causes click events to not trigger when performed on a composable with uneven corner radii.

This PR closes #495 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Implemented workarounds for this issue.

### Steps for testing
See that tests pass