### PR TITLE
`Bugfix`: Navigate to post after reply notification

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/DataStateUi.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/DataStateUi.kt
@@ -1,5 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.core.ui.common
 
+import android.util.Log
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -100,6 +101,7 @@ inline fun <T> Content(
 ) {
     when (dataState) {
         is DataState.Failure -> {
+            Log.e("DataStateUi", "Error loading data", dataState.throwable)
             Column(
                 modifier = Modifier
             ) {

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/MetisStorageService.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/MetisStorageService.kt
@@ -15,6 +15,10 @@ import kotlinx.coroutines.flow.Flow
  */
 interface MetisStorageService {
 
+    suspend fun <T> withTransaction(
+        block: suspend () -> T
+    ): T
+
     /**
      * Permanently store the given posts. If a post with an identical id already exists, the existing post is updated.
      * The answer posts are also updated by either being inserted or updated.

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceImpl.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/service/storage/impl/MetisStorageServiceImpl.kt
@@ -1,5 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.storage.impl
 
+import android.util.Log
 import androidx.paging.PagingSource
 import androidx.room.withTransaction
 import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.service.storage.MetisStorageService
@@ -25,6 +26,9 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.db.pojo.P
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Instant
 import java.util.UUID
+
+
+private const val TAG = "MetisStorageServiceImpl"
 
 /**
  * This implementation only displays live created posts, but ignores them when counting the posts for the next page request.
@@ -168,6 +172,10 @@ internal class MetisStorageServiceImpl(
         private val MetisContext.conversationId: Long get() = if (this is MetisContext.Conversation) conversationId else -1
     }
 
+    override suspend fun <T> withTransaction(block: suspend () -> T): T {
+        return databaseProvider.database.withTransaction(block)
+    }
+
     override suspend fun insertOrUpdatePosts(
         host: String,
         metisContext: MetisContext,
@@ -191,13 +199,18 @@ internal class MetisStorageServiceImpl(
     ) {
         // Extract the db entities from the network entities. With the schema invalid entities are discarded.
         for (sp in posts) {
+            if (sp.id == null) {
+                Log.w(TAG, "Post has no id. Cannot insert or update post.")
+                continue
+            }
+
             val queryClientPostId = metisDao.queryClientPostId(
                 serverId = host,
-                postId = sp.id ?: continue,
+                postId = sp.id!!,
                 postingType = BasePostingEntity.PostingType.STANDALONE
             )
 
-            insertOrUpdatePost(
+            val newClientPostId = insertOrUpdatePost(
                 metisDao = metisDao,
                 isNewPost = queryClientPostId == null,
                 host = host,
@@ -206,6 +219,10 @@ internal class MetisStorageServiceImpl(
                 sp = sp,
                 isLiveCreated = false
             )
+
+            if (newClientPostId == null) {
+                Log.w(TAG, "Post with id ${sp.id} could not be inserted or updated.")
+            }
         }
     }
 
@@ -240,6 +257,7 @@ internal class MetisStorageServiceImpl(
             )
 
             if (removeAllOlderPosts) {
+                Log.d(TAG, "Deleting all posts older than ${oldestPost.creationDate} for conversation ${metisContext.conversationId}")
                 metisDao.deletePostsOlderThanThreshold(
                     host = host,
                     courseId = metisContext.courseId,

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/thread/ConversationThreadUseCase.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/thread/ConversationThreadUseCase.kt
@@ -1,5 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.ui.thread
 
+import android.util.Log
 import de.tum.informatics.www1.artemis.native_app.core.common.flatMapLatest
 import de.tum.informatics.www1.artemis.native_app.core.data.DataState
 import de.tum.informatics.www1.artemis.native_app.core.data.retryOnInternet
@@ -36,6 +37,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.plus
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+
+
+private const val TAG = "ConversationThreadUseCase"
 
 /**
  * ViewModel for the standalone view of communication posts. Handles loading of the singular post by the given post id.
@@ -80,6 +84,7 @@ internal class ConversationThreadUseCase(
      * The post data state flow as loading from the server.
      */
     val post: StateFlow<DataState<IStandalonePost>> = postId.flatMapLatest { postId ->
+        Log.d(TAG, "ConversationThreadUseCase loading with postId: $postId")
         when (postId) {
             is StandalonePostId.ClientSideId -> metisStorageService
                 .getStandalonePost(postId.clientSideId)
@@ -176,26 +181,28 @@ internal class ConversationThreadUseCase(
 
         return when (standalonePostDataState) {
             is DataState.Success -> {
-                val post = standalonePostDataState.data
+                metisStorageService.withTransaction {
+                    val post = standalonePostDataState.data
 
-                val host = serverConfigurationService.host.first()
-                metisStorageService.insertOrUpdatePosts(
-                    host = host,
-                    metisContext = metisContext,
-                    posts = listOf(post)
-                )
+                    val host = serverConfigurationService.host.first()
+                    metisStorageService.insertOrUpdatePosts(
+                        host = host,
+                        metisContext = metisContext,
+                        posts = listOf(post)
+                    )
 
-                val clientSidePostId = metisStorageService.getClientSidePostId(
-                    host = host,
-                    serverSidePostId = post.id ?: 0L,
-                    postingType = BasePostingEntity.PostingType.STANDALONE
-                )
+                    val clientSidePostId = metisStorageService.getClientSidePostId(
+                        host = host,
+                        serverSidePostId = post.id ?: 0L,
+                        postingType = BasePostingEntity.PostingType.STANDALONE
+                    )
 
-                if (clientSidePostId != null) {
-                    metisStorageService
-                        .getStandalonePost(clientSidePostId)
-                        .asDataStateFlow()
-                } else failureFlow
+                    if (clientSidePostId != null) {
+                        metisStorageService
+                            .getStandalonePost(clientSidePostId)
+                            .asDataStateFlow()
+                    } else failureFlow
+                }
             }
 
             is DataState.Failure -> flowOf(DataState.Failure(standalonePostDataState.throwable))

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/thread/ConversationThreadUseCase.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/thread/ConversationThreadUseCase.kt
@@ -198,9 +198,10 @@ internal class ConversationThreadUseCase(
                     )
 
                     if (clientSidePostId != null) {
-                        metisStorageService
-                            .getStandalonePost(clientSidePostId)
-                            .asDataStateFlow()
+                        val storedPost = metisStorageService
+                            .getStandalonePost(clientSidePostId).first()
+
+                        flowOf(storedPost).asDataStateFlow()
                     } else failureFlow
                 }
             }

--- a/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/thread/ConversationThreadUseCase.kt
+++ b/feature/metis/conversation/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/ui/thread/ConversationThreadUseCase.kt
@@ -181,6 +181,9 @@ internal class ConversationThreadUseCase(
 
         return when (standalonePostDataState) {
             is DataState.Success -> {
+                // The transaction is needed to ensure that storing the post in the db and re-fetching it
+                // does not interfere with other transactions. Eg, when reloading, the ConversationChatListUseCase
+                // might delete older updated posts.
                 metisStorageService.withTransaction {
                     val post = standalonePostDataState.data
 

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/notification_model/target/CommunicationPostTarget.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/notification_model/target/CommunicationPostTarget.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-class CommunicationPostTarget(
+data class CommunicationPostTarget(
     @SerialName("message")
     val message: String,
     @SerialName("entity")

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
@@ -27,7 +27,6 @@ import de.tum.informatics.www1.artemis.native_app.feature.push.communication_not
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.ArtemisNotification
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.CommunicationNotificationType
 import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.ReplyPostCommunicationNotificationType
-import de.tum.informatics.www1.artemis.native_app.feature.push.notification_model.target.CommunicationPostTarget
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.CommunicationNotificationManager
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.delete.DeleteNotificationReceiver
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.mark_as_read.MarkAsReadReceiver
@@ -146,15 +145,6 @@ internal class CommunicationNotificationManagerImpl(
         val notificationChannel: ArtemisNotificationChannel =
             ArtemisNotificationChannel.CommunicationNotificationChannel
 
-        var metisTarget =
-            NotificationTargetManager.getCommunicationNotificationTarget(communication.targetString)
-
-        if (metisTarget.message == CommunicationPostTarget.MESSAGE_NEW_REPLY) {
-            // For answer notifications, we set the post id to the parentId of the post.
-            // This allows to navigate to the thread of the post.
-            metisTarget = metisTarget.copy(postId = communication.parentId)
-        }
-
         val notification = NotificationCompat.Builder(context, notificationChannel.id)
             .setStyle(buildMessagingStyle(communication, messages))
             .setSmallIcon(R.drawable.push_notification_icon)
@@ -162,7 +152,7 @@ internal class CommunicationNotificationManagerImpl(
             .setContentIntent(
                 NotificationTargetManager.getMetisContentIntent(
                     context = context,
-                    notificationTarget = metisTarget
+                    notificationTarget = communication.target
                 )
             )
             .setDeleteIntent(

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/util/NotificationTargetManager.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/util/NotificationTargetManager.kt
@@ -100,6 +100,10 @@ internal object NotificationTargetManager {
         return json.decodeFromString<CommunicationPostTarget>(target)
     }
 
+    fun CommunicationPostTarget.toJsonString(): String {
+        return json.encodeToString(CommunicationPostTarget.serializer(), this)
+    }
+
     private fun buildOpenAppIntent(context: Context): PendingIntent = PendingIntent.getActivity(
         context,
         0,


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
When clicking on a notification for a reply, the thread failed to load. This was for two main problems:
1. When storing the received notifications, we only stored the answerPostId for answer notifications. However, we need the id of the base post to navigate to the thread with the newly received answer.
2. When navigation to an older thread, the thread always failed to load. This is not directly related to the notification navigation, but could also be observed when receiving a notification about a new answer to an older post. This problem is also reproducible by saving an old post (go >20 posts up in the chat), and clicking on the post in the "Saved Messages" screen. Then the thread would also fail to load.

This PR closes #627.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
For fixing 1. :
- Store the basePost id as the `parentId` for answer notifications.
- Also, change the `metisTarget`s postId to the parentId. The postId is used to navigate to the thread.

For fixing 2. : 
- Wrap call to store fetched post in new `withTransaction` call
- Add `Log` calls to make future similar debugging easier

### Steps for testing
- Enable push notifications on the emulator
- With the webapp, write a new reply to an old post of the Android user (>20 posts above the newest post in the chat)
- Receive the push notification on Android
- Click on the notification
- See that the thread gets loaded successfully
