### PR TITLE
`Improvement`: Show notification quick-reply texts

### DIFF
--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationDao.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/communication_notification_model/PushCommunicationDao.kt
@@ -51,7 +51,8 @@ interface PushCommunicationDao {
         val message: CommunicationMessageEntity = try {
             val content = CommunicationNotificationPlaceholderContent.fromNotificationsPlaceholders(
                 type = artemisNotification.type,
-                notificationPlaceholders = artemisNotification.notificationPlaceholders
+                notificationPlaceholders = artemisNotification.notificationPlaceholders,
+                target = NotificationTargetManager.getCommunicationNotificationTarget(targetString)
             ) ?: return -1
 
             if (artemisNotification.type is ReplyPostCommunicationNotificationType) {

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/CommunicationNotificationManagerImpl.kt
@@ -134,13 +134,14 @@ internal class CommunicationNotificationManagerImpl(
         }
 
         if (communication != null && messages != null) {
-            popCommunicationNotification(communication, messages)
+            popCommunicationNotification(communication, messages, silent = true)
         }
     }
 
     private fun popCommunicationNotification(
         communication: PushCommunicationEntity,
-        messages: List<CommunicationMessageEntity>
+        messages: List<CommunicationMessageEntity>,
+        silent: Boolean = false
     ) {
         val notificationChannel: ArtemisNotificationChannel =
             ArtemisNotificationChannel.CommunicationNotificationChannel
@@ -149,6 +150,7 @@ internal class CommunicationNotificationManagerImpl(
             .setStyle(buildMessagingStyle(communication, messages))
             .setSmallIcon(R.drawable.push_notification_icon)
             .setAutoCancel(true)
+            .setSilent(silent)
             .setContentIntent(
                 NotificationTargetManager.getMetisContentIntent(
                     context = context,

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
@@ -10,7 +10,6 @@ import de.tum.informatics.www1.artemis.native_app.feature.metis.conversation.wor
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.MetisContext
 import de.tum.informatics.www1.artemis.native_app.feature.push.communication_notification_model.PushCommunicationEntity
 import de.tum.informatics.www1.artemis.native_app.feature.push.service.impl.notification_manager.BaseCommunicationNotificationReceiver
-import kotlinx.coroutines.runBlocking
 import org.koin.core.component.get
 
 /**
@@ -38,11 +37,6 @@ class ReplyReceiver : BaseCommunicationNotificationReceiver() {
                 parentPostId = communicationEntity.target.postId,
                 response = response
             )
-        }
-
-        // Repop the notification to tell the OS we handled the notification
-        runBlocking {
-            communicationNotificationManager.repopNotification(parentId = communicationEntity.parentId)
         }
     }
 

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/ReplyReceiver.kt
@@ -63,10 +63,10 @@ class ReplyReceiver : BaseCommunicationNotificationReceiver() {
                 OneTimeWorkRequestBuilder<UpdateReplyNotificationWorker>()
                     .setInputData(
                         BaseCreatePostWorker.createWorkInput(
-                            metisContext.courseId,
-                            metisContext.conversationId,
-                            clientSidePostId,
-                            response,
+                            courseId = metisContext.courseId,
+                            conversationId = metisContext.conversationId,
+                            clientSidePostId = clientSidePostId,
+                            content = response,
                             postType = BaseCreatePostWorker.PostType.ANSWER_POST,
                             parentPostId = parentPostId
                         )

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/UpdateReplyNotificationWorker.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/UpdateReplyNotificationWorker.kt
@@ -33,7 +33,7 @@ class UpdateReplyNotificationWorker(
                 val account = accountData.data
 
                 communicationNotificationManager.addSelfMessage(
-                    parentId = parentPostId ?: conversationId,
+                    parentId = parentPostId ?: return Result.failure(),
                     authorLoginName = account.username ?: "self",
                     authorName = account.humanReadableName,
                     authorImageUrl = account.imageUrl,

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/UpdateReplyNotificationWorker.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/impl/notification_manager/reply/UpdateReplyNotificationWorker.kt
@@ -26,7 +26,6 @@ class UpdateReplyNotificationWorker(
         forwardedSourcePostList: List<ForwardedSourcePostContent>,
         parentPostId: Long?
     ): Result {
-        // We can add to the notification that the user has responded. However, this does not have super high priority
         val accountData = accountDataService.getAccountData()
 
         return when (accountData) {
@@ -34,7 +33,7 @@ class UpdateReplyNotificationWorker(
                 val account = accountData.data
 
                 communicationNotificationManager.addSelfMessage(
-                    parentId = conversationId,
+                    parentId = parentPostId ?: conversationId,
                     authorLoginName = account.username ?: "self",
                     authorName = account.humanReadableName,
                     authorImageUrl = account.imageUrl,


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
When using the quick-reply feature to reply to a notification, the answer was not displayed in the notification (as expected eg from WhatsApp).
This PR closes #216 


### Steps for testing
1. Activate push notifications on Android
2. Receive a communication notification
3. Click "Reply" and write a reply to that notification
4. See that after sending the quick-reply, this reply text is also shown as a second part of the notification

### Screenshots
![image](https://github.com/user-attachments/assets/c80ecef4-2d76-4933-b2ef-79ca75e33234)
