### PR TITLE
`Improvement`: Remove attachment tab

### DIFF
--- a/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
+++ b/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
@@ -66,8 +66,7 @@ internal fun ExerciseOverviewTab(
                 .padding(horizontal = Spacings.ScreenHorizontalSpacing),
             text = stringResource(id = R.string.exercise_view_overview_problem_statement),
             style = MaterialTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Medium
             )
         )
 

--- a/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
+++ b/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
@@ -66,7 +66,8 @@ internal fun ExerciseOverviewTab(
                 .padding(horizontal = Spacings.ScreenHorizontalSpacing),
             text = stringResource(id = R.string.exercise_view_overview_problem_statement),
             style = MaterialTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.Medium
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.primary,
             )
         )
 

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/AttachmentsSection.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/AttachmentsSection.kt
@@ -24,7 +24,7 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.common.EmptyListHint
 import de.tum.informatics.www1.artemis.native_app.core.ui.date.getRelativeTime
 
 @Composable
-internal fun AttachmentsTab(
+internal fun AttachmentsSection(
     modifier: Modifier,
     attachments: List<Attachment>,
     onClickFileAttachment: (Attachment) -> Unit,

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureOverviewTab.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureOverviewTab.kt
@@ -168,8 +168,7 @@ private fun LazyListScope.overviewSection(
                     .background(MaterialTheme.colorScheme.background),
                 text = stringResource(id = R.string.lecture_view_overview_section_title),
                 style = MaterialTheme.typography.headlineSmall.copy(
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
+                    fontWeight = FontWeight.Bold
                 )
             )
         }
@@ -342,8 +341,7 @@ private fun LazyListScope.attachmentsSection(
                     .padding(vertical = 16.dp),
                 text = stringResource(id = R.string.lecture_view_tab_attachments),
                 style = MaterialTheme.typography.headlineSmall.copy(
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
+                    fontWeight = FontWeight.Bold
                 )
             )
         }
@@ -373,8 +371,7 @@ private fun LazyListScope.lectureUnitSection(
                 .background(MaterialTheme.colorScheme.background),
             text = stringResource(id = R.string.lecture_view_overview_section_lecture_units),
             style = MaterialTheme.typography.headlineSmall.copy(
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
+                fontWeight = FontWeight.Bold
             )
         )
     }

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureOverviewTab.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureOverviewTab.kt
@@ -161,42 +161,45 @@ private fun LazyListScope.overviewSection(
     channel: ChannelChat?,
     lecture: Lecture
 ) {
-    if (startDate != null || description != null || channel != null) {
-        stickyHeader {
-            Text(
-                modifier = Modifier
-                    .background(MaterialTheme.colorScheme.background),
-                text = stringResource(id = R.string.lecture_view_overview_section_title),
-                style = MaterialTheme.typography.headlineSmall.copy(
-                    fontWeight = FontWeight.Bold
-                )
-            )
-        }
+    if (startDate == null && description == null && channel == null) {
+        return
+    }
 
-        startDate?.let {
-            dateSection(
-                modifier = modifier.fillMaxWidth(),
-                startDate = it,
-                endDate = endDate
+    stickyHeader {
+        Text(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background),
+            text = stringResource(id = R.string.lecture_view_overview_section_title),
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontWeight = FontWeight.Bold
             )
-        }
+        )
+    }
 
-        description?.let {
-            descriptionSection(
-                modifier = modifier.fillMaxWidth(),
-                description = it
-            )
-        }
+    startDate?.let {
+        dateSection(
+            modifier = modifier.fillMaxWidth(),
+            startDate = it,
+            endDate = endDate
+        )
+    }
 
-        channel?.let {
-            channelSection(
-                modifier = modifier.fillMaxWidth(),
-                channel = it,
-                lecture = lecture
-            )
-        }
+    description?.let {
+        descriptionSection(
+            modifier = modifier.fillMaxWidth(),
+            description = it
+        )
+    }
+
+    channel?.let {
+        channelSection(
+            modifier = modifier.fillMaxWidth(),
+            channel = it,
+            lecture = lecture
+        )
     }
 }
+
 
 private fun LazyListScope.dateSection(
     modifier: Modifier,
@@ -333,27 +336,29 @@ private fun LazyListScope.attachmentsSection(
     onClickFileAttachment: (Attachment) -> Unit,
     onClickOpenLinkAttachment: (Attachment) -> Unit
 ) {
-    if (attachments.isNotEmpty()) {
-        stickyHeader {
-            Text(
-                modifier = modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(vertical = 16.dp),
-                text = stringResource(id = R.string.lecture_view_tab_attachments),
-                style = MaterialTheme.typography.headlineSmall.copy(
-                    fontWeight = FontWeight.Bold
-                )
-            )
-        }
+    if (attachments.isEmpty()) {
+       return
+    }
 
-        item {
-            AttachmentsSection(
-                modifier = Modifier.fillMaxSize(),
-                attachments = attachments,
-                onClickFileAttachment = onClickFileAttachment,
-                onClickOpenLinkAttachment = onClickOpenLinkAttachment
+    stickyHeader {
+        Text(
+            modifier = modifier
+                .background(MaterialTheme.colorScheme.background)
+                .padding(vertical = 16.dp),
+            text = stringResource(id = R.string.lecture_view_tab_attachments),
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontWeight = FontWeight.Bold
             )
-        }
+        )
+    }
+
+    item {
+        AttachmentsSection(
+            modifier = Modifier.fillMaxSize(),
+            attachments = attachments,
+            onClickFileAttachment = onClickFileAttachment,
+            onClickOpenLinkAttachment = onClickOpenLinkAttachment
+        )
     }
 }
 

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureOverviewTab.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureOverviewTab.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -74,6 +75,7 @@ internal fun LectureOverviewTab(
     lecture: Lecture,
     lectureChannel: DataState<ChannelChat>,
     lectureUnits: List<LectureUnitData>,
+    attachments: List<Attachment>,
     onViewExercise: (exerciseId: Long) -> Unit,
     onMarkAsCompleted: (lectureUnitId: Long, isCompleted: Boolean) -> Unit,
     onRequestViewLink: (String) -> Unit,
@@ -112,20 +114,14 @@ internal fun LectureOverviewTab(
         state = state,
         contentPadding = Spacings.calculateContentPaddingValues()
     ) {
-        startDate?.let {
-            dateSection(
-                modifier = Modifier.fillMaxWidth(),
-                startDate = it,
-                endDate = endDate
-            )
-        }
-
-        description?.let {
-            descriptionSection(
-                modifier = Modifier.fillMaxWidth(),
-                description = it
-            )
-        }
+        overviewSection(
+            modifier = Modifier,
+            startDate = startDate,
+            endDate = endDate,
+            description = description,
+            channel = channel,
+            lecture = lecture
+        )
 
         if (lectureUnits.isNotEmpty()) {
             lectureUnitSection(
@@ -142,10 +138,61 @@ internal fun LectureOverviewTab(
             )
         }
 
+        if (attachments.isNotEmpty()) {
+            attachmentsSection(
+                modifier = Modifier.fillMaxSize(),
+                attachments = lecture.attachments,
+                onClickFileAttachment = onRequestOpenAttachment,
+                onClickOpenLinkAttachment = {
+                    onRequestViewLink(
+                        it.link ?: return@attachmentsSection
+                    )
+                }
+            )
+        }
+    }
+}
+
+private fun LazyListScope.overviewSection(
+    modifier: Modifier,
+    startDate: Instant?,
+    endDate: Instant?,
+    description: String?,
+    channel: ChannelChat?,
+    lecture: Lecture
+) {
+    if (startDate != null || description != null || channel != null) {
+        stickyHeader {
+            Text(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.background),
+                text = stringResource(id = R.string.lecture_view_overview_section_title),
+                style = MaterialTheme.typography.headlineSmall.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+
+        startDate?.let {
+            dateSection(
+                modifier = modifier.fillMaxWidth(),
+                startDate = it,
+                endDate = endDate
+            )
+        }
+
+        description?.let {
+            descriptionSection(
+                modifier = modifier.fillMaxWidth(),
+                description = it
+            )
+        }
+
         channel?.let {
             channelSection(
-                modifier = Modifier.fillMaxWidth(),
-                channel = channel,
+                modifier = modifier.fillMaxWidth(),
+                channel = it,
                 lecture = lecture
             )
         }
@@ -281,6 +328,37 @@ private fun LazyListScope.channelSection(
     }
 }
 
+private fun LazyListScope.attachmentsSection(
+    modifier: Modifier,
+    attachments: List<Attachment>,
+    onClickFileAttachment: (Attachment) -> Unit,
+    onClickOpenLinkAttachment: (Attachment) -> Unit
+) {
+    if (attachments.isNotEmpty()) {
+        stickyHeader {
+            Text(
+                modifier = modifier
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(vertical = 16.dp),
+                text = stringResource(id = R.string.lecture_view_tab_attachments),
+                style = MaterialTheme.typography.headlineSmall.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+
+        item {
+            AttachmentsSection(
+                modifier = Modifier.fillMaxSize(),
+                attachments = attachments,
+                onClickFileAttachment = onClickFileAttachment,
+                onClickOpenLinkAttachment = onClickOpenLinkAttachment
+            )
+        }
+    }
+}
+
 private fun LazyListScope.lectureUnitSection(
     modifier: Modifier,
     lectureUnits: List<LectureUnitData>,
@@ -290,10 +368,13 @@ private fun LazyListScope.lectureUnitSection(
 ) {
     stickyHeader {
         Text(
-            modifier = modifier.background(MaterialTheme.colorScheme.background),
+            modifier = modifier
+                .padding(vertical = 16.dp)
+                .background(MaterialTheme.colorScheme.background),
             text = stringResource(id = R.string.lecture_view_overview_section_lecture_units),
-            style = MaterialTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.Medium
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
             )
         )
     }

--- a/feature/lecture-view/src/main/res/values/lecture_strings.xml
+++ b/feature/lecture-view/src/main/res/values/lecture_strings.xml
@@ -10,6 +10,8 @@
     <string name="lecture_view_tab_attachments">Attachments</string>
 
     <!--  Overview tab   -->
+    lecture_view_overview_section_title
+    <string name="lecture_view_overview_section_title">Overview</string>
     <string name="lecture_view_overview_section_date">Date</string>
     <string name="lecture_view_overview_section_description">Description</string>
     <string name="lecture_view_overview_section_communication">Communication</string>

--- a/feature/lecture-view/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lecture_view/LectureE2eTest.kt
+++ b/feature/lecture-view/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lecture_view/LectureE2eTest.kt
@@ -35,7 +35,6 @@ import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.course_cr
 import de.tum.informatics.www1.artemis.native_app.core.test.test_setup.course_creation.createTextLectureUnit
 import de.tum.informatics.www1.artemis.native_app.feature.lectureview.LectureScreen
 import de.tum.informatics.www1.artemis.native_app.feature.lectureview.LectureViewModel
-import de.tum.informatics.www1.artemis.native_app.feature.lectureview.R
 import de.tum.informatics.www1.artemis.native_app.feature.lectureview.TEST_TAG_OVERVIEW_LIST
 import de.tum.informatics.www1.artemis.native_app.feature.lectureview.getLectureUnitTestTag
 import de.tum.informatics.www1.artemis.native_app.feature.lectureview.lectureModule
@@ -148,10 +147,6 @@ class LectureE2eTest : BaseComposeTest() {
         }
 
         assertEquals(loadedAttachments.size, 3, "Expected 3 attachments")
-
-        composeTestRule
-            .onNodeWithText(context.getString(R.string.lecture_view_tab_attachments))
-            .performClick()
 
         attachments.forEach { attachment ->
             composeTestRule.onNodeWithText(attachment.name!!).assertExists()


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The attachment tab will be removed and the content display under the lecture overview if an attachment exist (almost deprecated). Also hierarchy was missing on Lectures so the screen should be arrance by giving bigger titles and adding a overview section that wraps up, date, description and communication.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Lecture tabs removed.
Overview title added.
Lecture Unit title is bigger.
The attachemnt placed under lecture units.

### Steps for testing
Open App and go to lectures.

Verify overview title is visible lecture unit and overview are in the same size as headers, rest should be in same.
Verify tabs are removed and everything works as before.

### Screenshots
<img width="200" alt="Screenshot 2025-06-12 at 13 48 34" src="https://github.com/user-attachments/assets/d5e88953-34a7-46d4-b0a9-ceab158d3d48" />

<img width="200" alt="Screenshot 2025-06-12 at 13 48 36" src="https://github.com/user-attachments/assets/516db228-1309-4e30-b03a-7bc1276a3e89" />