### PR TITLE
`Improvement`: Adapt navigation  bar colors

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/alert/TextAlertDialog.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/alert/TextAlertDialog.kt
@@ -2,6 +2,7 @@ package de.tum.informatics.www1.artemis.native_app.core.ui.alert
 
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -119,6 +120,7 @@ private fun TextAlertImpl(
                     Text(text = dismissButtonText)
                 }
             }
-        }
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainer
     )
 }

--- a/feature/course-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseview/ui/course_overview/CourseScaffold.kt
+++ b/feature/course-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseview/ui/course_overview/CourseScaffold.kt
@@ -11,8 +11,10 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -22,6 +24,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -171,7 +174,12 @@ private fun BottomNavigationBar(
                     },
                     onClick = {
                         onUpdateSelectedTab(navigationItem.route)
-                    }
+                    },
+                    colors = NavigationBarItemDefaults.colors(
+                        selectedIconColor = MaterialTheme.colorScheme.primary,
+                        selectedTextColor = MaterialTheme.colorScheme.primary,
+                        indicatorColor = Color.Transparent
+                    )
                 )
             }
         }


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The color adaption was missing for bottom navigation and some alerts.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
The bottom navigation and Alert colors aligned

### Steps for testing
Open app click to settings.
Go to notification setting and toggle, see sync alert is now on the color scheme we use.
Go back to course, check bottom nagivation the indicator is transparent and selected tab is on primary color

### Screenshots
<img width="284" alt="Screenshot 2025-06-15 at 11 30 08" src="https://github.com/user-attachments/assets/e0f83007-6845-40e9-9e0f-c86f4459723b" />
<img width="284" alt="Screenshot 2025-06-15 at 11 30 15" src="https://github.com/user-attachments/assets/89ea13c0-f5d5-45aa-bc83-3751f9f4db69" />
