### PR TITLE
Bugfix/lecture/display attachments on lecture

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/AttachmentHandler.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/AttachmentHandler.kt
@@ -1,0 +1,87 @@
+package de.tum.informatics.www1.artemis.native_app.core.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import de.tum.informatics.www1.artemis.native_app.core.common.artemis_context.authTokenOrEmptyString
+import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.LinkBottomSheet
+import de.tum.informatics.www1.artemis.native_app.core.ui.compose.LinkBottomSheetState
+import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.AttachmentUtil
+import de.tum.informatics.www1.artemis.native_app.core.ui.remote_resources.ImageFile
+import de.tum.informatics.www1.artemis.native_app.core.ui.remote_resources.pdf.PdfFile
+
+@Composable
+fun AttachmentHandler(
+    url: String?,
+    onDismiss: () -> Unit
+) {
+    if (url == null) return
+
+    val context = LocalContext.current
+    val artemisContext by LocalArtemisContextProvider.current.collectArtemisContextAsState()
+
+    val fileName = url.substringAfterLast("/")
+    val type = AttachmentUtil.detectAttachmentType(url)
+
+    when (type) {
+        is AttachmentUtil.AttachmentType.PDF -> {
+            val pdfFile = PdfFile(
+                url,
+                artemisContext.authTokenOrEmptyString,
+                fileName
+            )
+            LinkBottomSheet(
+                modifier = Modifier.fillMaxSize(),
+                state = LinkBottomSheetState.PDFVIEWSTATE(pdfFile),
+                onDismissRequest = onDismiss
+            )
+        }
+
+        is AttachmentUtil.AttachmentType.Image -> {
+            val imageFile = ImageFile(
+                url,
+                artemisContext.authTokenOrEmptyString,
+                fileName
+            )
+            LinkBottomSheet(
+                modifier = Modifier.fillMaxSize(),
+                state = LinkBottomSheetState.IMAGEVIEWSTATE(imageFile),
+                onDismissRequest = onDismiss
+            )
+        }
+
+        is AttachmentUtil.AttachmentType.Other -> {
+            DownloadAttachmentDialog(
+                onDismissRequest = onDismiss,
+                onDownload = {
+                    AttachmentUtil.downloadAttachment(
+                        context = context,
+                        artemisContext = artemisContext,
+                        link = url,
+                        name = fileName
+                    )
+                    onDismiss()
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun DownloadAttachmentDialog(
+    onDismissRequest: () -> Unit,
+    onDownload: () -> Unit
+) {
+    TextAlertDialog(
+        title = stringResource(id = R.string.download_attachment_dialog_title),
+        text = stringResource(id = R.string.download_attachment_dialog_message),
+        confirmButtonText = stringResource(id = R.string.download_file_attachment_dialog_positive),
+        dismissButtonText = stringResource(id = R.string.download__file_attachment_dialog_negative),
+        onPressPositiveButton = onDownload,
+        onDismissRequest = onDismissRequest
+    )
+} 

--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/markdown/AttachmentUtil.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/markdown/AttachmentUtil.kt
@@ -1,4 +1,4 @@
-package de.tum.informatics.www1.artemis.native_app.feature.lectureview
+package de.tum.informatics.www1.artemis.native_app.core.ui.markdown
 
 import android.content.Context
 import android.webkit.MimeTypeMap
@@ -11,15 +11,15 @@ import io.ktor.http.appendPathSegments
 import java.io.File
 import java.net.URLEncoder
 
-object LectureUnitAttachmentUtil {
+object AttachmentUtil {
 
-    sealed class LectureAttachmentType(val mimeTypePattern: String) {
-        data object PDF : LectureAttachmentType("application/pdf")
-        data object Image : LectureAttachmentType("image/")
-        data object Other : LectureAttachmentType("*/*")
+    sealed class AttachmentType(val mimeTypePattern: String) {
+        data object PDF : AttachmentType("application/pdf")
+        data object Image : AttachmentType("image/")
+        data object Other : AttachmentType("*/*")
     }
 
-    internal fun buildOpenAttachmentLink(
+    fun buildOpenAttachmentLink(
         serverUrl: String,
         attachmentLink: String
     ): String {
@@ -31,7 +31,7 @@ object LectureUnitAttachmentUtil {
 
     // Necessary to encode the file name for the attachment URL, see
     // https://github.com/ls1intum/Artemis/blob/develop/src/main/webapp/app/shared/http/file.service.ts
-    internal fun createAttachmentFileUrl(downloadUrl: String, downloadName: String, encodeName: Boolean): String {
+    fun createAttachmentFileUrl(downloadUrl: String, downloadName: String, encodeName: Boolean): String {
         val downloadUrlComponents = downloadUrl.split("/")
         val extension = downloadUrlComponents.lastOrNull()?.substringAfterLast('.', "") ?: ""
         val restOfUrl = downloadUrlComponents.dropLast(1).joinToString("/")
@@ -43,20 +43,20 @@ object LectureUnitAttachmentUtil {
         return "$restOfUrl/student/$encodedDownloadName"
     }
 
-    internal fun detectAttachmentType(link: String?): LectureAttachmentType {
-        if (link.isNullOrEmpty()) return LectureAttachmentType.Other
+    fun detectAttachmentType(link: String?): AttachmentType {
+        if (link.isNullOrEmpty()) return AttachmentType.Other
 
-        val extension = MimeTypeMap.getFileExtensionFromUrl(link)?.lowercase() ?: return LectureAttachmentType.Other
-        val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) ?: return LectureAttachmentType.Other
+        val extension = MimeTypeMap.getFileExtensionFromUrl(link)?.lowercase() ?: return AttachmentType.Other
+        val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) ?: return AttachmentType.Other
 
         return when {
-            mimeType == LectureAttachmentType.PDF.mimeTypePattern -> LectureAttachmentType.PDF
-            mimeType.startsWith(LectureAttachmentType.Image.mimeTypePattern) -> LectureAttachmentType.Image
-            else -> LectureAttachmentType.Other
+            mimeType == AttachmentType.PDF.mimeTypePattern -> AttachmentType.PDF
+            mimeType.startsWith(AttachmentType.Image.mimeTypePattern) -> AttachmentType.Image
+            else -> AttachmentType.Other
         }
     }
 
-    internal fun downloadAttachment(
+    fun downloadAttachment(
         context: Context,
         artemisContext: ArtemisContext,
         name: String?,

--- a/core/ui/src/main/res/values/attachment_handler_string.xml
+++ b/core/ui/src/main/res/values/attachment_handler_string.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="download_attachment_dialog_title">Download File?</string>
+    <string name="download_attachment_dialog_message">This file cannot be viewed. Do you want to download it instead?</string>
+    <string name="download_file_attachment_dialog_positive">Download</string>
+    <string name="download__file_attachment_dialog_negative">Cancel</string>
+</resources>

--- a/feature/faq/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/faq/ui/FaqArtemisMarkdownTransformer.kt
+++ b/feature/faq/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/faq/ui/FaqArtemisMarkdownTransformer.kt
@@ -1,10 +1,12 @@
 package de.tum.informatics.www1.artemis.native_app.feature.faq.ui
 
+import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import de.tum.informatics.www1.artemis.native_app.core.common.markdown.ArtemisMarkdownTransformer
 import io.ktor.http.URLBuilder
 import io.ktor.http.appendPathSegments
+import io.noties.markwon.LinkResolver
 
 
 @Composable
@@ -30,5 +32,24 @@ class FaqArtemisMarkdownTransformer(
         }.buildString()
         val link = "[$fileName]($url)"
         return if (isImage) "!$link" else link
+    }
+}
+
+/**
+ * Link resolver for markdown text in the faq view.
+ * If the link is a protected file, it will be opened in a bottom sheet.
+ * Otherwise, it will be opened in a browser.
+ */
+class FaqLinkResolver(
+    private val serverUrl: String,
+    private val onRequestOpenAttachment: (String) -> Unit,
+    private val onRequestOpenLink: (String) -> Unit
+) : LinkResolver {
+    override fun resolve(view: View, link: String) {
+        if (link.startsWith(serverUrl) && link.contains("/api/core/files/markdown")) {
+            onRequestOpenAttachment(link)
+        } else {
+            onRequestOpenLink(link)
+        }
     }
 }

--- a/feature/faq/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/faq/ui/detail/FaqDetailContent.kt
+++ b/feature/faq/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/faq/ui/detail/FaqDetailContent.kt
@@ -20,7 +20,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -29,19 +33,26 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.toRoute
 import de.tum.informatics.www1.artemis.native_app.core.data.DataState
+import de.tum.informatics.www1.artemis.native_app.core.ui.AttachmentHandler
+import de.tum.informatics.www1.artemis.native_app.core.ui.LocalLinkOpener
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
+import de.tum.informatics.www1.artemis.native_app.core.ui.alert.TextAlertDialog
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.BasicDataStateUi
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.AdaptiveNavigationIcon
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.ArtemisTopAppBar
 import de.tum.informatics.www1.artemis.native_app.core.ui.deeplinks.FaqDeeplinks
 import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.LocalMarkdownTransformer
+import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.LocalMarkwon
+import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.MarkdownRenderFactory
 import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.MarkdownText
-import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.ProvideMarkwon
 import de.tum.informatics.www1.artemis.native_app.core.ui.navigation.animatedComposable
+import de.tum.informatics.www1.artemis.native_app.core.ui.remote_images.LocalArtemisImageProvider
 import de.tum.informatics.www1.artemis.native_app.feature.faq.R
 import de.tum.informatics.www1.artemis.native_app.feature.faq.repository.data.Faq
+import de.tum.informatics.www1.artemis.native_app.feature.faq.ui.FaqLinkResolver
 import de.tum.informatics.www1.artemis.native_app.feature.faq.ui.rememberFaqArtemisMarkdownTransformer
 import de.tum.informatics.www1.artemis.native_app.feature.faq.ui.shared.FaqCategoryChipFlowRow
+import io.noties.markwon.LinkResolver
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -87,7 +98,8 @@ fun FaqDetailContent(
             modifier = Modifier.fillMaxSize(),
             faqDataState = faq,
             onReloadRequest = viewModel::onRequestReload,
-            onSidebarToggle = onSidebarToggle
+            onSidebarToggle = onSidebarToggle,
+            serverUrl = serverUrl
         )
     }
 }
@@ -98,6 +110,7 @@ fun FaqDetailUi(
     faqDataState: DataState<Faq>,
     onReloadRequest: () -> Unit,
     onSidebarToggle: () -> Unit,
+    serverUrl: String
 ) {
     Scaffold(
         modifier = modifier,
@@ -124,15 +137,60 @@ fun FaqDetailUi(
             retryButtonText = stringResource(id = R.string.faq_loading_faq_try_again),
             onClickRetry = onReloadRequest
         ) { faq ->
-            ProvideMarkwon(
-                useOriginalImageSize = true
+
+            val context = LocalContext.current
+            val markdownTransformer = rememberFaqArtemisMarkdownTransformer(serverUrl)
+            val imageLoader = LocalArtemisImageProvider.current.rememberArtemisImageLoader()
+            val linkOpener = LocalLinkOpener.current
+
+            var pendingOpenFileAttachmentByUrl: String? by remember { mutableStateOf(null) }
+            var pendingOpenLink: String? by remember { mutableStateOf(null) }
+
+            val linkResolver = remember(serverUrl) {
+                FaqLinkResolver(
+                    serverUrl = serverUrl,
+                    onRequestOpenAttachment = { pendingOpenFileAttachmentByUrl = it },
+                    onRequestOpenLink = { pendingOpenLink = it }
+                )
+            }
+
+            val markwon = remember(linkResolver, imageLoader) {
+                MarkdownRenderFactory.create(context, imageLoader, linkResolver)
+            }
+
+            CompositionLocalProvider(
+                LocalMarkdownTransformer provides markdownTransformer,
+                LocalMarkwon provides markwon
             ) {
                 FaqDetail(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState())
                         .navigationBarsPadding(),
-                    faq = faq
+                    faq = faq,
+                    linkResolver = linkResolver
+                )
+            }
+
+            AttachmentHandler(
+                url = pendingOpenFileAttachmentByUrl,
+                onDismiss = { pendingOpenFileAttachmentByUrl = null }
+            )
+
+            if (pendingOpenLink != null) {
+                TextAlertDialog(
+                    title = stringResource(id = R.string.faq_open_link_dialog_title),
+                    text = stringResource(
+                        id = R.string.faq_open_link_dialog_message,
+                        pendingOpenLink.orEmpty()
+                    ),
+                    confirmButtonText = stringResource(id = R.string.faq_link_dialog_positive),
+                    dismissButtonText = stringResource(id = R.string.faq_link_dialog_negative),
+                    onPressPositiveButton = {
+                        linkOpener.openLink(pendingOpenLink.orEmpty())
+                        pendingOpenLink = null
+                    },
+                    onDismissRequest = { pendingOpenLink = null }
                 )
             }
         }
@@ -143,6 +201,7 @@ fun FaqDetailUi(
 private fun FaqDetail(
     modifier: Modifier = Modifier,
     faq: Faq,
+    linkResolver: LinkResolver
 ) {
     Column(
         modifier = modifier,
@@ -160,6 +219,7 @@ private fun FaqDetail(
         MarkdownText(
             markdown = faq.questionAnswer,
             style = MaterialTheme.typography.bodyLarge,
+            linkResolver = linkResolver
         )
 
         Spacer(modifier = Modifier

--- a/feature/faq/src/main/res/values/faq_strings.xml
+++ b/feature/faq/src/main/res/values/faq_strings.xml
@@ -16,5 +16,14 @@
     <string name="faq_search_hint">Search for an FAQ</string>
     <string name="faq_details_title">FAQ Details</string>
 
+    <string name="faq_open_link_dialog_title">Open link?</string>
+    <string name="faq_open_link_dialog_message">%1$s</string>
+    <string name="faq_link_dialog_positive">Open</string>
+    <string name="faq_link_dialog_negative">@android:string/cancel</string>
+
+    <string name="faq_failed_dialog_title">Error!</string>
+    <string name="faq_failed_dialog_message">Something went wrong while setting the lecture unit as completed.</string>
+    <string name="faq_failed_dialog_positive">@android:string/ok</string>
+
 
 </resources>

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureArtemisMarkdownTransformer.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureArtemisMarkdownTransformer.kt
@@ -1,0 +1,34 @@
+package de.tum.informatics.www1.artemis.native_app.feature.lectureview
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import de.tum.informatics.www1.artemis.native_app.core.common.markdown.ArtemisMarkdownTransformer
+import io.ktor.http.URLBuilder
+import io.ktor.http.appendPathSegments
+
+
+@Composable
+fun rememberLectureArtemisMarkdownTransformer(serverUrl: String): LectureArtemisMarkdownTransformer {
+    return remember(serverUrl) {
+        val strippedServerUrl = serverUrl.removeSuffix("/")
+        LectureArtemisMarkdownTransformer(strippedServerUrl)
+    }
+}
+
+
+class LectureArtemisMarkdownTransformer(
+    private val serverUrl: String
+) : ArtemisMarkdownTransformer() {
+
+    override fun transformFileUploadMessageMarkdown(
+        isImage: Boolean,
+        fileName: String,
+        filePath: String
+    ): String {
+        val url = URLBuilder(serverUrl).apply {
+            appendPathSegments(filePath)
+        }.buildString()
+        val link = "[$fileName]($url)"
+        return if (isImage) "!$link" else link
+    }
+}

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureArtemisMarkdownTransformer.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureArtemisMarkdownTransformer.kt
@@ -1,10 +1,12 @@
 package de.tum.informatics.www1.artemis.native_app.feature.lectureview
 
+import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import de.tum.informatics.www1.artemis.native_app.core.common.markdown.ArtemisMarkdownTransformer
 import io.ktor.http.URLBuilder
 import io.ktor.http.appendPathSegments
+import io.noties.markwon.LinkResolver
 
 
 @Composable
@@ -30,5 +32,24 @@ class LectureArtemisMarkdownTransformer(
         }.buildString()
         val link = "[$fileName]($url)"
         return if (isImage) "!$link" else link
+    }
+}
+
+/**
+ * Link resolver for markdown text in the lecture view.
+ * If the link is a protected file, it will be opened in a bottom sheet.
+ * Otherwise, it will be opened in a browser.
+ */
+class LectureLinkResolver(
+    private val serverUrl: String,
+    private val onRequestOpenAttachment: (String) -> Unit,
+    private val onRequestOpenLink: (String) -> Unit
+) : LinkResolver {
+    override fun resolve(view: View, link: String) {
+        if (link.startsWith(serverUrl) && (link.contains("/api/files/attachments/lecture") || link.contains("/api/core/files/markdown"))) {
+            onRequestOpenAttachment(link)
+        } else {
+            onRequestOpenLink(link)
+        }
     }
 }

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureOverviewTab.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureOverviewTab.kt
@@ -60,6 +60,7 @@ import de.tum.informatics.www1.artemis.native_app.feature.lectureview.lecture_un
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.common.getChannelIconImageVector
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.humanReadableName
+import io.noties.markwon.LinkResolver
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 
@@ -78,6 +79,7 @@ internal fun LectureOverviewTab(
     onMarkAsCompleted: (lectureUnitId: Long, isCompleted: Boolean) -> Unit,
     onRequestViewLink: (String) -> Unit,
     onRequestOpenAttachment: (Attachment) -> Unit,
+    linkResolver: LinkResolver,
     state: LazyListState
 ) {
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
@@ -123,7 +125,8 @@ internal fun LectureOverviewTab(
         description?.let {
             descriptionSection(
                 modifier = Modifier.fillMaxWidth(),
-                description = it
+                description = it,
+                linkResolver = linkResolver
             )
         }
 
@@ -186,7 +189,8 @@ private fun LazyListScope.dateSection(
 
 private fun LazyListScope.descriptionSection(
     modifier: Modifier,
-    description: String
+    description: String,
+    linkResolver: LinkResolver
 ) {
     stickyHeader {
         Text(
@@ -204,7 +208,8 @@ private fun LazyListScope.descriptionSection(
         MarkdownText(
             modifier = modifier.animateItem(),
             markdown = description,
-            style = MaterialTheme.typography.bodyMedium
+            style = MaterialTheme.typography.bodyMedium,
+            linkResolver = linkResolver
         )
         Spacer(modifier = Modifier.height(8.dp))
     }

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureScreenBody.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureScreenBody.kt
@@ -27,6 +27,7 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.common.BasicDataStateUi
 import de.tum.informatics.www1.artemis.native_app.core.ui.material.DefaultTab
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
+import io.noties.markwon.LinkResolver
 import kotlinx.coroutines.Deferred
 
 @Composable
@@ -42,6 +43,7 @@ internal fun LectureScreenBody(
     onDisplaySetCompletedFailureDialog: () -> Unit,
     onReloadLecture: () -> Unit,
     onUpdateLectureUnitIsComplete: (lectureUnitId: Long, isCompleted: Boolean) -> Deferred<Boolean>,
+    linkResolver: LinkResolver
 ) {
     val selectedTabIndexState = rememberSaveable {
         mutableIntStateOf(0)
@@ -128,6 +130,7 @@ internal fun LectureScreenBody(
                         },
                         onRequestViewLink = onRequestViewLink,
                         onRequestOpenAttachment = onRequestOpenAttachment,
+                        linkResolver = linkResolver,
                         state = overviewListState
                     )
                 }

--- a/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureScreenUi.kt
+++ b/feature/lecture-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/lectureview/LectureScreenUi.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,6 +39,8 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.common.top_app_bar.Art
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.LinkBottomSheet
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.LinkBottomSheetState
 import de.tum.informatics.www1.artemis.native_app.core.ui.deeplinks.LectureDeeplinks
+import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.LocalMarkdownTransformer
+import de.tum.informatics.www1.artemis.native_app.core.ui.markdown.ProvideMarkwon
 import de.tum.informatics.www1.artemis.native_app.core.ui.navigation.animatedComposable
 import de.tum.informatics.www1.artemis.native_app.core.ui.remote_resources.ImageFile
 import de.tum.informatics.www1.artemis.native_app.core.ui.remote_resources.pdf.PdfFile
@@ -164,24 +167,29 @@ internal fun LectureScreen(
             )
         }
     ) { padding ->
-        LectureScreenBody(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = padding.calculateTopPadding())
-                .consumeWindowInsets(WindowInsets.systemBars.only(WindowInsetsSides.Top)),
-            lectureDataState = lectureDataState,
-            lectureChannel = lectureChannel,
-            lectureUnits = lectureUnits,
-            onViewExercise = onViewExercise,
-            overviewListState = overviewListState,
-            onRequestViewLink = { pendingOpenLink = it },
-            onRequestOpenAttachment = { pendingOpenFileAttachment = it },
-            onDisplaySetCompletedFailureDialog = {
-                displaySetCompletedFailureDialog = true
-            },
-            onReloadLecture = onReloadLecture,
-            onUpdateLectureUnitIsComplete = onUpdateLectureUnitIsComplete,
-        )
+        val markdownTransformer = rememberLectureArtemisMarkdownTransformer(serverUrl)
+        CompositionLocalProvider(LocalMarkdownTransformer provides markdownTransformer) {
+            ProvideMarkwon {
+                LectureScreenBody(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = padding.calculateTopPadding())
+                        .consumeWindowInsets(WindowInsets.systemBars.only(WindowInsetsSides.Top)),
+                    lectureDataState = lectureDataState,
+                    lectureChannel = lectureChannel,
+                    lectureUnits = lectureUnits,
+                    onViewExercise = onViewExercise,
+                    overviewListState = overviewListState,
+                    onRequestViewLink = { pendingOpenLink = it },
+                    onRequestOpenAttachment = { pendingOpenFileAttachment = it },
+                    onDisplaySetCompletedFailureDialog = {
+                        displaySetCompletedFailureDialog = true
+                    },
+                    onReloadLecture = onReloadLecture,
+                    onUpdateLectureUnitIsComplete = onUpdateLectureUnitIsComplete,
+                )
+            }
+        }
 
         val currentPendingOpenFileAttachment = pendingOpenFileAttachment
         if (currentPendingOpenFileAttachment != null) {

--- a/feature/lecture-view/src/main/res/values/lecture_strings.xml
+++ b/feature/lecture-view/src/main/res/values/lecture_strings.xml
@@ -25,11 +25,6 @@
     <string name="lecture_view_open_video_link_button">Open video link</string>
     <string name="lecture_view_open_attachment_button">Open attachment</string>
 
-    <string name="lecture_view_open_file_attachment_dialog_title">Download File?</string>
-    <string name="lecture_view_open_file_attachment_dialog_message">This file cannot be viewed. Do you want to download it instead?</string>
-    <string name="lecture_view_open_file_attachment_dialog_positive">Download</string>
-    <string name="lecture_view_open_file_attachment_dialog_negative">Cancel</string>
-
     <!--  Attachments Tab  -->
     <string name="lecture_view_attachments_empty">This lecture has no attachments.</string>
     <string name="lecture_view_attachments_pdf">PDF</string>


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
In lecture and faq markdown internal link wont be opening the bottom sheet for pdf. Also foe lecture the images not ddisplaying so this faq fixes that.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Fixed the handling of internal links in markdown to correctly trigger the bottom sheet for embedded files (e.g., PDFs).
Ensured embedded images inside lecture descriptions and FAQ content are rendered correctly.
Applied the same improvements to both Lecture and FAQ markdown rendering logic for consistency.


### Steps for testing
Create a lecture and faq has embeded image and file inside of the text content.

  - Create a Lecture and a FAQ entry that includes:
    - An embedded image 
    - An internal file link (e.g., a link to a PDF).
- Open the app and navigate to the Lecture.
      - Verify that the embedded image is displayed in the description.
      - Tap the internal link and ensure it opens the bottom sheet correctly.
- Repeat the same steps for the FAQ.
    - Confirm that both images and internal links behave as expected.

### Screenshots
<img width="277" alt="Screenshot 2025-06-21 at 22 46 18" src="https://github.com/user-attachments/assets/68973f4d-1dcb-4b36-bf8e-a7bc5f9a8bb0" />
<img width="277" alt="Screenshot 2025-06-21 at 22 46 09" src="https://github.com/user-attachments/assets/cedf16fb-911e-41ad-8c69-223733ca061b" />
