### PR TITLE
`Improvement`: Course circular indicator size arrangement

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/course/CourseItem.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/common/course/CourseItem.kt
@@ -51,6 +51,7 @@ import de.tum.informatics.www1.artemis.native_app.core.model.CourseWithScore
 import de.tum.informatics.www1.artemis.native_app.core.model.exercise.Exercise
 import de.tum.informatics.www1.artemis.native_app.core.model.exercise.latestParticipation
 import de.tum.informatics.www1.artemis.native_app.core.model.upcomingExercises
+import de.tum.informatics.www1.artemis.native_app.core.ui.ArtemisAppLayout
 import de.tum.informatics.www1.artemis.native_app.core.ui.LocalLinkOpener
 import de.tum.informatics.www1.artemis.native_app.core.ui.R
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
@@ -60,6 +61,7 @@ import de.tum.informatics.www1.artemis.native_app.core.ui.common.course.util.Cou
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.BackgroundColorBasedTextColor
 import de.tum.informatics.www1.artemis.native_app.core.ui.deeplinks.ExerciseDeeplinks
 import de.tum.informatics.www1.artemis.native_app.core.ui.exercise.CoursePointsDecimalFormat
+import de.tum.informatics.www1.artemis.native_app.core.ui.getArtemisAppLayout
 import de.tum.informatics.www1.artemis.native_app.core.ui.material.colors.CourseColors
 import java.text.DecimalFormat
 
@@ -128,9 +130,11 @@ fun CourseItem(
                 )
 
                 if (currentPoints > 0f) {
+                    val isTablet = getArtemisAppLayout() == ArtemisAppLayout.Tablet
+
                     Box(
                         modifier = Modifier
-                            .weight(0.5f)
+                            .width(if (isTablet) 150.dp else 120.dp)
                             .aspectRatio(1f)
                     ) {
                         CircularCourseProgress(


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
The circular indicator overflows in tablet
<img width="507" alt="Screenshot 2025-06-26 at 23 29 54" src="https://github.com/user-attachments/assets/d1a2b7d2-2d97-49c4-96ce-d0dd36d55529" />


### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Fix size is used for phone and tablet layouts

### Steps for testing
Open the app 

Check a course with circular indicator
Verify the phone and tablet indicator size is looking good and tablet is not overflowing

### Screenshots
<img width="507" alt="Screenshot 2025-06-26 at 23 23 57" src="https://github.com/user-attachments/assets/6c539af9-5295-435b-bb4a-52ad20304998" />
<img width="241" alt="Screenshot 2025-06-26 at 23 22 48" src="https://github.com/user-attachments/assets/a4147ada-482a-4150-89c2-877b07578a78" />
