### PR TITLE
`Improvement`: Display exercise channel similar to lecture screen

### DIFF
--- a/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseInformation.kt
+++ b/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseInformation.kt
@@ -54,14 +54,6 @@ fun ExerciseInformation(
             exercise = exercise,
             isLongToolbar = isLongToolbar
         )
-
-        exerciseChannel?.let {
-            ExerciseChannelLink(
-                modifier = Modifier.fillMaxWidth(),
-                exercise = exercise,
-                exerciseChannel = exerciseChannel
-            )
-        }
     }
 }
 

--- a/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseInformation.kt
+++ b/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseInformation.kt
@@ -1,7 +1,6 @@
 package de.tum.informatics.www1.artemis.native_app.feature.exerciseview.home.overview
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,10 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,14 +19,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import de.tum.informatics.www1.artemis.native_app.core.model.exercise.Exercise
-import de.tum.informatics.www1.artemis.native_app.core.ui.LocalLinkOpener
 import de.tum.informatics.www1.artemis.native_app.core.ui.date.DateFormats
 import de.tum.informatics.www1.artemis.native_app.core.ui.date.format
 import de.tum.informatics.www1.artemis.native_app.core.ui.exercise.ExerciseCategoryChipRow
 import de.tum.informatics.www1.artemis.native_app.core.ui.exercise.ExerciseInfoChip
 import de.tum.informatics.www1.artemis.native_app.feature.exerciseview.R
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
-import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.humanReadableName
 import kotlinx.datetime.Instant
 
 private val exerciseInformationColumnModifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
@@ -44,7 +37,6 @@ val informationTableThickness = 1.dp
 fun ExerciseInformation(
     modifier: Modifier,
     exercise: Exercise,
-    exerciseChannel: ChannelChat?,
     isLongToolbar: Boolean
 ) {
     Column(modifier = modifier) {
@@ -245,54 +237,5 @@ private fun DateInfoText(
             color = MaterialTheme.colorScheme.onSurface,
             style = MaterialTheme.typography.bodyMedium,
         )
-    }
-}
-
-@Composable
-private fun ExerciseChannelLink(
-    modifier: Modifier,
-    exercise: Exercise,
-    exerciseChannel: ChannelChat
-) {
-    val localLinkOpener = LocalLinkOpener.current
-
-    Row(
-        modifier = modifier
-            .padding(start = 8.dp)
-            .padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        Text(
-            modifier = Modifier,
-            text = stringResource(R.string.exercise_view_overview_hint_exercise_communication),
-            style = MaterialTheme.typography.bodyMedium
-        )
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        Row(
-            modifier = Modifier.clickable {
-                val courseId = exercise.course?.id
-                courseId?.let {
-                    localLinkOpener.openLink("artemis://courses/$courseId/messages?conversationId=${exerciseChannel.id}")
-                }
-            },
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                modifier = Modifier,
-                text = exerciseChannel.humanReadableName.removePrefix("exercise-"),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary
-            )
-
-            Icon(
-                modifier = Modifier,
-                imageVector = Icons.Default.ChevronRight,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary
-            )
-        }
     }
 }

--- a/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
+++ b/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
@@ -144,7 +144,6 @@ internal fun ExerciseOverviewTab(
                         shape = MaterialTheme.shapes.extraSmall
                     ),
                 exercise = exercise,
-                exerciseChannel = exerciseChannel,
                 isLongToolbar = isLongToolbar
             )
         }

--- a/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
+++ b/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/home/overview/ExerciseOverviewTab.kt
@@ -2,8 +2,11 @@ package de.tum.informatics.www1.artemis.native_app.feature.exerciseview.home.ove
 
 import android.annotation.SuppressLint
 import android.webkit.WebView
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,10 +14,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -23,13 +31,17 @@ import com.google.accompanist.web.WebViewState
 import de.tum.informatics.www1.artemis.native_app.core.model.exercise.Exercise
 import de.tum.informatics.www1.artemis.native_app.core.model.exercise.ProgrammingExercise
 import de.tum.informatics.www1.artemis.native_app.core.model.exercise.QuizExercise
+import de.tum.informatics.www1.artemis.native_app.core.ui.LocalLinkOpener
 import de.tum.informatics.www1.artemis.native_app.core.ui.Spacings
 import de.tum.informatics.www1.artemis.native_app.core.ui.compose.ArtemisWebView
+import de.tum.informatics.www1.artemis.native_app.core.ui.deeplinks.CommunicationDeeplinks
 import de.tum.informatics.www1.artemis.native_app.core.ui.exercise.ExerciseActionButtons
 import de.tum.informatics.www1.artemis.native_app.core.ui.exercise.ExerciseActions
 import de.tum.informatics.www1.artemis.native_app.core.ui.exercise.ProvideDefaultExerciseTemplateStatus
 import de.tum.informatics.www1.artemis.native_app.feature.exerciseview.R
 import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.content.dto.conversation.ChannelChat
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.common.getChannelIconImageVector
+import de.tum.informatics.www1.artemis.native_app.feature.metis.shared.ui.humanReadableName
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -73,6 +85,16 @@ internal fun ExerciseOverviewTab(
             Spacer(modifier = Modifier.height(8.dp))
 
             ExerciseOverviewChips(exercise = exercise)
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (exerciseChannel != null) {
+                ExerciseChannel(
+                    modifier.padding(horizontal = Spacings.ScreenHorizontalSpacing),
+                    exercise,
+                    exerciseChannel
+                )
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
 
@@ -124,6 +146,75 @@ internal fun ExerciseOverviewTab(
                 exercise = exercise,
                 exerciseChannel = exerciseChannel,
                 isLongToolbar = isLongToolbar
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExerciseChannel(
+    modifier: Modifier,
+    exercise: Exercise,
+    channel: ChannelChat
+) {
+    val localLinkOpener = LocalLinkOpener.current
+
+    Text(
+        text = stringResource(id = R.string.exercise_view_overview_section_communication),
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.background),
+        style = MaterialTheme.typography.titleSmall.copy(
+            fontWeight = FontWeight.Bold
+        )
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth(),
+        onClick = {
+            val courseId = exercise.course?.id
+            courseId?.let {
+                localLinkOpener.openLink(
+                    CommunicationDeeplinks.ToConversation.inAppLink(
+                        it,
+                        channel.id
+                    )
+                )
+            }
+        },
+    ) {
+        Row(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surfaceContainer)
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                modifier = Modifier.weight(1f),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Icon(
+                    modifier = Modifier.height(24.dp),
+                    imageVector = getChannelIconImageVector(channel),
+                    contentDescription = null
+                )
+
+                Text(
+                    text = channel.humanReadableName.removePrefix("exercise-"),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+
+            Icon(
+                modifier = Modifier.height(24.dp),
+                tint = MaterialTheme.colorScheme.primary,
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null
             )
         }
     }

--- a/feature/exercise-view/src/main/res/values/exercise_view_strings.xml
+++ b/feature/exercise-view/src/main/res/values/exercise_view_strings.xml
@@ -92,4 +92,6 @@
     <string name="exercise_list_exercises_no_search_results_body">\"%s\" did not match any exercises.</string>
     <string name="exercise_list_exercise_item_not_selected">Please select a exercise from the list.</string>
 
+    <string name="exercise_view_overview_section_communication">Communication</string>
+
 </resources>


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
In the usability test users have commented that it is not very clear to find channel on the exercise screen also it is look different from the lectures. 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Exercise channel displayed separate as in lectures.

### Steps for testing
Open exercise 
See the channel above the Problem description
See the navigation to channel is working as it is

### Screenshots
<img width="263" height="519" alt="Screenshot 2025-07-12 at 21 43 17" src="https://github.com/user-attachments/assets/81e572dc-a1d0-4dc9-bed2-db19df9268e5" />

