### PR TITLE
`Feature`: Add passkey deletion option

### DIFF
--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/service/PasskeySettingsService.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/service/PasskeySettingsService.kt
@@ -16,4 +16,6 @@ interface PasskeySettingsService: LoggedInBasedService {
 
     suspend fun registerPasskey(registerPasskeyJson: String): NetworkResponse<RegisterPasskeyResponseDTO>
 
+    suspend fun deletePasskey(credentialId: String): NetworkResponse<Unit>
+
 }

--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/service/impl/PasskeySettingsServiceImpl.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/service/impl/PasskeySettingsServiceImpl.kt
@@ -52,4 +52,12 @@ class PasskeySettingsServiceImpl(
             setBody(RegisterRequest(publicKey))
         }
     }
+
+    override suspend fun deletePasskey(credentialId: String): NetworkResponse<Unit> {
+        return deleteRequest {
+            url {
+                appendPathSegments("webauthn", "register", credentialId)
+            }
+        }
+    }
 }

--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/ui/passkeys/PasskeysSection.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/ui/passkeys/PasskeysSection.kt
@@ -2,13 +2,18 @@ package de.tum.informatics.www1.artemis.native_app.feature.settings.ui.passkeys
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Key
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -27,6 +32,7 @@ fun PasskeysSection(
     modifier: Modifier = Modifier,
     passkeysDataState: DataState<List<PasskeyDTO>>,
     onCreatePasskey: () -> Unit,
+    onDeletePasskey: (PasskeyDTO) -> Unit,
 ) {
     ArtemisSection(
         modifier = modifier,
@@ -37,25 +43,41 @@ fun PasskeysSection(
             dataState = passkeysDataState,
         ) { passkeys ->
             for (passkey in passkeys) {
-                Column(
+                Row(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text(
-                        text = passkey.label,
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Bold
-                    )
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = passkey.label,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold
+                        )
 
-                    Text(
-                        text = stringResource(
-                            R.string.passkey_settings_created_at_label,
-                            passkey.created.format(DateFormats.OnlyDate.format)
-                        ),
-                        style = MaterialTheme.typography.labelMedium,
-                    )
+                        Text(
+                            text = stringResource(
+                                R.string.passkey_settings_created_at_label,
+                                passkey.created.format(DateFormats.OnlyDate.format)
+                            ),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    }
+                    
+                    IconButton(
+                        onClick = { onDeletePasskey(passkey) }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = stringResource(R.string.passkey_settings_delete_key),
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                    }
                 }
             }
 

--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/ui/passkeys/PasskeysUseCase.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/ui/passkeys/PasskeysUseCase.kt
@@ -83,4 +83,16 @@ class PasskeysUseCase(
             }
         }
     }
+
+    fun deletePasskey(credentialId: String): Deferred<CreationResult> {
+        return coroutineScope.async {
+            val response = passkeySettingsService.deletePasskey(credentialId)
+            if (response is NetworkResponse.Failure) {
+                Log.e(TAG, "Failed to delete passkey: ${response.exception}")
+                return@async CreationResult.Failure(response.exception.localizedMessage ?: "Unknown error")
+            }
+            Log.d(TAG, "Successfully deleted passkey with credential ID: $credentialId")
+            CreationResult.Success
+        }
+    }
 }

--- a/feature/settings/src/main/res/values/account_settings_strings.xml
+++ b/feature/settings/src/main/res/values/account_settings_strings.xml
@@ -28,5 +28,11 @@
     <string name="passkey_settings_create_failure_dialog_desc">Consider retrying the creation.\nDetails:</string>
     <string name="passkey_settings_create_failure_dialog_ok">@android:string/ok</string>
 
+    <string name="passkey_settings_delete_key">Delete passkey</string>
+    <string name="passkey_settings_section_delete_passkey_title">Delete passkey?</string>
+    <string name="passkey_settings_section_delete_passkey_message">**Are you sure to delete the passkey %1$s?** This is a permanent action and cannot be undone.</string>
+    <string name="passkey_settings_section_delete_passkey_negative">@android:string/cancel</string>
+    <string name="passkey_settings_delete_success">Successfully deleted passkey</string>
+    <string name="passkey_settings_delete_failed">Failed to delete passkey</string>
 
 </resources>


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
It is not possible to manage passkeys  from android app.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Trash button added next to passkey
Api call for deletePasskey added

### Steps for testing
1 Add a passkey from web and android app
2 Try to delete them from app

### Screenshots

https://github.com/user-attachments/assets/6d681746-2d11-4ddd-81bf-beb28a3cb283


