### PR TITLE
`Improvement`:Arrange user setting to look more native

### DIFF
--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/ui/SettingsScreen.kt
@@ -15,6 +15,9 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -164,7 +167,7 @@ private fun UserInformationSection(
 ) {
     ArtemisSection(
         modifier = modifier,
-        title = stringResource(id = R.string.settings_account_information_section)
+        title = stringResource(id = R.string.settings_account_information_header)
     ) {
         AnimatedDataStateUi(
             dataState = accountDataState,
@@ -182,20 +185,23 @@ private fun UserInformationSection(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     ProfilePicture(
-                        modifier = Modifier.size(52.dp),
+                        modifier = Modifier.size(48.dp),
                         profilePictureData = ProfilePictureData.fromAccount(account)
                     )
 
-                    Spacer(modifier = Modifier.width(8.dp))
+                    Spacer(modifier = Modifier.width(16.dp))
 
-                    Column {
+                    Column(
+                        verticalArrangement = Arrangement.Center
+                    ) {
                         Text(
-                            text = account.name.orEmpty(),
+                            text = stringResource(id = R.string.settings_account_information_section),
                             style = MaterialTheme.typography.bodyLarge
                         )
                         Text(
-                            text = account.username.orEmpty(),
-                            style = MaterialTheme.typography.bodySmall
+                            text = stringResource(id = R.string.settings_account_information_section_subtext),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
@@ -208,13 +214,39 @@ private fun UserInformationSection(
 private fun NotificationSection(modifier: Modifier, onOpenNotificationSettings: () -> Unit) {
     ArtemisSection (
         modifier = modifier,
-        title = stringResource(id = R.string.settings_notification_section)
+        title = stringResource(id = R.string.settings_notification_header),
     ) {
         ButtonEntry(
             modifier = Modifier.fillMaxWidth(),
-            text = stringResource(id = R.string.settings_notification_settings),
             onClick = onOpenNotificationSettings
-        )
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Notifications,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp).padding(8.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.width(16.dp))
+
+                Column(
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.settings_notification_section),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Text(
+                        text = stringResource(id = R.string.settings_notification_settings),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/feature/settings/src/main/res/values/settings_strings.xml
+++ b/feature/settings/src/main/res/values/settings_strings.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="settings_screen_title">Settings</string>
+    <string name="settings_account_information_header">Account</string>
     <string name="settings_account_information_section">Account information</string>
+    <string name="settings_account_information_section_subtext">Profile, passkey</string>
     <string name="settings_account_information_full_name">Full name:</string>
     <string name="settings_account_information_login">Login:</string>
     <string name="settings_account_information_email">Email:</string>
     <string name="settings_account_logout">Logout</string>
 
+    <string name="settings_notification_header">Notification</string>
     <string name="settings_notification_section">Notifications</string>
-    <string name="settings_notification_settings">Open notification settings</string>
+    <string name="settings_notification_settings">Notification settings</string>
 
     <string name="settings_about_section">About</string>
     <string name="settings_server_specifics_information">Imprint and privacy policy depend on the server you have currently selected.</string>


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
In the settings, users sometimes can find the passkey, also the design is not feeling similar to native 

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Instead of profile name etc, general header added again with subtitle, that indicates other action can be taken in the next step. Such as Account information -> User will see profile and option to add passkey so ( Profile, passkey)

### Steps for testing
Open app
Go to settings
See visually account and notification is clearly display and sub actions also visible as footer text

### Screenshots
<img width="295" height="541" alt="Screenshot 2025-07-19 at 17 03 37" src="https://github.com/user-attachments/assets/4c2010e4-24b4-4ba4-b76a-f4b22c4e4528" />

