### PR TITLE
`Improvement`: Display recommend update one time

### DIFF
--- a/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/ui/MainActivity.kt
+++ b/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/ui/MainActivity.kt
@@ -246,10 +246,11 @@ class MainActivity : AppCompatActivity(),
             }
 
             LaunchedEffect(updateResult?.minVersion) {
-                if (updateResult?.updateAvailable == true) {
+                if (updateResult?.showRecommended == true) {
                     navController.navigateToUpdateScreen(
                         updateResult!!.currentVersion,
-                        updateResult!!.minVersion
+                        updateResult!!.minVersion,
+                        updateResult!!.recommendedVersion
                     )
                 }
             }
@@ -262,7 +263,7 @@ class MainActivity : AppCompatActivity(),
                             Intent(this@MainActivity, OssLicensesMenuActivity::class.java)
                         startActivity(intent)
                     },
-                    onOpenPlayStore = ::openPlayStore
+                    onOpenPlayStore = ::openPlayStore,
                 )
             }
         }

--- a/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/ui/MainActivity.kt
+++ b/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/ui/MainActivity.kt
@@ -246,7 +246,7 @@ class MainActivity : AppCompatActivity(),
             }
 
             LaunchedEffect(updateResult?.minVersion) {
-                if (updateResult?.showRecommended == true) {
+                if (updateResult?.updateAvailable == true) {
                     navController.navigateToUpdateScreen(
                         updateResult!!.currentVersion,
                         updateResult!!.minVersion,
@@ -264,6 +264,11 @@ class MainActivity : AppCompatActivity(),
                         startActivity(intent)
                     },
                     onOpenPlayStore = ::openPlayStore,
+                    onSkipUpdate = {
+                        // Mark this recommended update as dismissed
+                        updateRepository.dismissRecommendedUpdate()
+                        navController.navigateUp()
+                    }
                 )
             }
         }

--- a/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/ui/RootNavGraph.kt
+++ b/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/ui/RootNavGraph.kt
@@ -35,7 +35,8 @@ import de.tum.informatics.www1.artemis.native_app.feature.settings.ui.settingsNa
 fun NavGraphBuilder.rootNavGraph(
     navController: NavController,
     onDisplayThirdPartyLicenses: () -> Unit,
-    onOpenPlayStore : () -> Unit
+    onOpenPlayStore: () -> Unit,
+    onSkipUpdate: () -> Unit
 ) {
     val onNavigateToTextExerciseParticipation =
         { exerciseId: Long, participationId: Long ->
@@ -179,9 +180,7 @@ fun NavGraphBuilder.rootNavGraph(
 
     updateNavGraph(
         onOpenPlayStore = onOpenPlayStore,
-        onSkipUpdate = {
-            navController.navigateUp()
-        }
+        onSkipUpdate = onSkipUpdate
     )
 
     courseNotificationScreen(

--- a/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/ui/RootNavGraph.kt
+++ b/app/src/main/java/de/tum/informatics/www1/artemis/native_app/android/ui/RootNavGraph.kt
@@ -178,7 +178,10 @@ fun NavGraphBuilder.rootNavGraph(
     )
 
     updateNavGraph(
-        onOpenPlayStore = onOpenPlayStore
+        onOpenPlayStore = onOpenPlayStore,
+        onSkipUpdate = {
+            navController.navigateUp()
+        }
     )
 
     courseNotificationScreen(

--- a/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/repository/UpdateRepository.kt
+++ b/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/repository/UpdateRepository.kt
@@ -40,6 +40,8 @@ class UpdateRepository(
         val updateAvailable: Boolean,
         val forceUpdate: Boolean,
         val currentVersion: NormalizedAppVersion,
-        val minVersion: NormalizedAppVersion
+        val minVersion: NormalizedAppVersion,
+        val recommendedVersion: NormalizedAppVersion,
+        val showRecommended: Boolean
     )
 }

--- a/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/repository/UpdateRepository.kt
+++ b/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/repository/UpdateRepository.kt
@@ -19,6 +19,7 @@ class UpdateRepository(
 
     private var lastCheckedTimestamp: Long = 0L
     private var lastResult: UpdateResult? = null
+    private var isCurrentRecommendedUpdateDismissed = false
 
     private val currentVersionNormalized = appVersionProvider.appVersion.normalized
 
@@ -31,9 +32,29 @@ class UpdateRepository(
             response = response,
             currentVersion = currentVersionNormalized
         )
+        
+        // Check if this recommended update should be shown
+        val shouldShowRecommended = if (result.updateAvailable && !result.forceUpdate) {
+            !isCurrentRecommendedUpdateDismissed
+        } else {
+            result.updateAvailable
+        }
+        
+        val finalResult = result.copy(updateAvailable = shouldShowRecommended)
+        
         lastCheckedTimestamp = now
-        lastResult = result
-        _updateResultFlow.value = result
+        lastResult = finalResult
+        _updateResultFlow.value = finalResult
+    }
+
+    fun dismissRecommendedUpdate() {
+        isCurrentRecommendedUpdateDismissed = true
+        // Update the current result to not show the update
+        lastResult?.let { result ->
+            if (!result.forceUpdate) {
+                _updateResultFlow.value = result.copy(updateAvailable = false)
+            }
+        }
     }
 
     data class UpdateResult(
@@ -41,7 +62,6 @@ class UpdateRepository(
         val forceUpdate: Boolean,
         val currentVersion: NormalizedAppVersion,
         val minVersion: NormalizedAppVersion,
-        val recommendedVersion: NormalizedAppVersion,
-        val showRecommended: Boolean
+        val recommendedVersion: NormalizedAppVersion
     )
 }

--- a/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/repository/UpdateUtil.kt
+++ b/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/repository/UpdateUtil.kt
@@ -28,13 +28,21 @@ object UpdateUtil {
 
                 // 🔍 Version check
                 val serverMinVersion = data.minVersion
+                val serverRecommendedVersion = data.recommendedVersion
+                
+                // Check if update is required (current version below min version)
                 val updateRequired = serverMinVersion > currentVersion
+                
+                // Check if update is recommended (current version below recommended version but above min version)
+                val updateRecommended = !updateRequired && serverRecommendedVersion > currentVersion
 
                 UpdateRepository.UpdateResult(
-                    updateAvailable = updateRequired,
+                    updateAvailable = updateRequired || updateRecommended,
                     forceUpdate = updateRequired,
                     currentVersion = currentVersion,
-                    minVersion = serverMinVersion
+                    minVersion = serverMinVersion,
+                    recommendedVersion = serverRecommendedVersion,
+                    showRecommended = updateRecommended
                 )
             }
 
@@ -42,7 +50,9 @@ object UpdateUtil {
                 updateAvailable = false,
                 forceUpdate = false,
                 currentVersion = currentVersion,
-                minVersion = currentVersion
+                minVersion = currentVersion,
+                recommendedVersion = currentVersion,
+                showRecommended = false
             )
         }
     }

--- a/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/repository/UpdateUtil.kt
+++ b/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/repository/UpdateUtil.kt
@@ -41,8 +41,7 @@ object UpdateUtil {
                     forceUpdate = updateRequired,
                     currentVersion = currentVersion,
                     minVersion = serverMinVersion,
-                    recommendedVersion = serverRecommendedVersion,
-                    showRecommended = updateRecommended
+                    recommendedVersion = serverRecommendedVersion
                 )
             }
 
@@ -51,8 +50,7 @@ object UpdateUtil {
                 forceUpdate = false,
                 currentVersion = currentVersion,
                 minVersion = currentVersion,
-                recommendedVersion = currentVersion,
-                showRecommended = false
+                recommendedVersion = currentVersion
             )
         }
     }

--- a/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/ui/UpdateNavGraph.kt
+++ b/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/ui/UpdateNavGraph.kt
@@ -10,30 +10,42 @@ import kotlinx.serialization.Serializable
 @Serializable
 private data class UpdateScreenRoute(
     val currentVersion: String,
-    val minVersion: String
+    val minVersion: String,
+    val recommendedVersion: String
 )
 
 fun NavController.navigateToUpdateScreen(
     currentVersion: NormalizedAppVersion,
-    minVersion: NormalizedAppVersion
+    minVersion: NormalizedAppVersion,
+    recommendedVersion: NormalizedAppVersion
 ) {
-    navigate(UpdateScreenRoute(currentVersion.toString(), minVersion.toString())) {
+    navigate(
+        UpdateScreenRoute(
+            currentVersion = currentVersion.toString(),
+            minVersion = minVersion.toString(),
+            recommendedVersion = recommendedVersion.toString()
+        )
+    ) {
         popUpTo(graph.startDestinationId) { inclusive = true }
     }
 }
 
 fun NavGraphBuilder.updateNavGraph(
     onOpenPlayStore: () -> Unit,
+    onSkipUpdate: () -> Unit
 ) {
     composable<UpdateScreenRoute> { backStackEntry ->
         val route: UpdateScreenRoute = backStackEntry.toRoute()
         val currentVersion = NormalizedAppVersion(route.currentVersion)
         val minVersion = NormalizedAppVersion(route.minVersion)
+        val recommendedVersion = NormalizedAppVersion(route.recommendedVersion)
 
         UpdateScreen(
             onDownloadClick = onOpenPlayStore,
+            onSkipClick = onSkipUpdate,
             currentVersion = currentVersion,
-            minVersion = minVersion
+            minVersion = minVersion,
+            recommendedVersion = recommendedVersion
         )
     }
 }

--- a/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/ui/UpdateScreen.kt
+++ b/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/ui/UpdateScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,9 +30,13 @@ import de.tum.informatics.www1.artemis.native_app.feature.forceupdate.R
 @Composable
 fun UpdateScreen(
     onDownloadClick: () -> Unit,
+    onSkipClick: () -> Unit,
     currentVersion: NormalizedAppVersion,
-    minVersion: NormalizedAppVersion
+    minVersion: NormalizedAppVersion,
+    recommendedVersion: NormalizedAppVersion
 ) {
+    val isRecommended = recommendedVersion > minVersion && currentVersion > minVersion
+
     Scaffold { paddingValues ->
         Column(
             modifier = Modifier
@@ -63,7 +68,11 @@ fun UpdateScreen(
                 )
 
                 Text(
-                    text = stringResource(R.string.update_screen_download_message),
+                    text = if (isRecommended) {
+                        stringResource(R.string.update_screen_recommended_download_message)
+                    } else {
+                        stringResource(R.string.update_screen_download_message)
+                    },
                     style = MaterialTheme.typography.bodyLarge,
                     textAlign = TextAlign.Center
                 )
@@ -71,22 +80,46 @@ fun UpdateScreen(
                 Spacer(modifier = Modifier.height(Spacings.UpdateScreen.medium))
 
                 Text(
-                    text = stringResource(
-                        R.string.update_screen_version_info,
-                        currentVersion,
-                        minVersion
-                    ),
+                    text = if (isRecommended) {
+                        stringResource(
+                            R.string.update_screen_recommended_version_info,
+                            currentVersion,
+                            recommendedVersion
+                        )
+                    } else {
+                        stringResource(
+                            R.string.update_screen_version_info,
+                            currentVersion,
+                            minVersion
+                        )
+                    },
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colorScheme.secondary
                 )
 
             }
+
+            // Download button
             Button(
-                onClick = onDownloadClick,
+                onClick = {
+                    onDownloadClick()
+                },
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(text = stringResource(R.string.update_screen_downlaod_button))
+            }
+
+            if (isRecommended) {
+                Spacer(modifier = Modifier.height(Spacings.UpdateScreen.medium))
+                TextButton(
+                    onClick = {
+                        onSkipClick()
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(text = "Skip")
+                }
             }
         }
     }

--- a/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/ui/UpdateScreen.kt
+++ b/feature/force-update/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/ui/UpdateScreen.kt
@@ -35,7 +35,7 @@ fun UpdateScreen(
     minVersion: NormalizedAppVersion,
     recommendedVersion: NormalizedAppVersion
 ) {
-    val isRecommended = recommendedVersion > minVersion && currentVersion > minVersion
+    val isRecommended = recommendedVersion > currentVersion && currentVersion > minVersion
 
     Scaffold { paddingValues ->
         Column(
@@ -111,7 +111,6 @@ fun UpdateScreen(
             }
 
             if (isRecommended) {
-                Spacer(modifier = Modifier.height(Spacings.UpdateScreen.medium))
                 TextButton(
                     onClick = {
                         onSkipClick()

--- a/feature/force-update/src/main/res/values/update_screen_strings.xml
+++ b/feature/force-update/src/main/res/values/update_screen_strings.xml
@@ -2,9 +2,13 @@
 <resources>
     <string name="update_screen_new_update_available">New update available</string>
     <string name="update_screen_download_message">Please update Artemis to the latest version to ensure you have a smooth experience. You can download the latest version from the Play Store.</string>
+    <string name="update_screen_recommended_download_message">A new version of Artemis is available with improvements and new features. We recommend updating to the latest version for the best experience.</string>
     <string name="update_screen_downlaod_button">Download</string>
     <string name="update_screen_version_info">
     You are using version %1$s while the oldest version currently supported is %2$s.
+    </string>
+    <string name="update_screen_recommended_version_info">
+    You are using version %1$s while the recommended version is %2$s.
     </string>
 
 </resources>

--- a/feature/force-update/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/UpdateUtilTest.kt
+++ b/feature/force-update/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/UpdateUtilTest.kt
@@ -25,7 +25,7 @@ class UpdateUtilTest {
     private val version1_3_0 = NormalizedAppVersion("1.3.0")
 
     @Test
-    fun `processUpdateResponse should detect update if server min version is higher`() {
+    fun `processUpdateResponse should detect force update if server min version is higher`() {
         val response = NetworkResponse.Response(
             UpdateServiceResult(
                 minVersion = version1_3_0,
@@ -40,6 +40,26 @@ class UpdateUtilTest {
         assertTrue(result.forceUpdate)
         assertEquals(version1_2_3, result.currentVersion)
         assertEquals(version1_3_0, result.minVersion)
+        assertEquals(version1_3_0, result.recommendedVersion)
+        assertTrue(result.showRecommended)
+    }
+
+    @Test
+    fun `processUpdateResponse should detect recommended update if current version is below recommended but above min`() {
+        val response = NetworkResponse.Response(
+            UpdateServiceResult(
+                minVersion = version1_1_9,
+                recommendedVersion = version1_3_0,
+                features = listOf("new-feature")
+            )
+        )
+        val result = UpdateUtil.processUpdateResponse(response, currentVersion = version1_2_3)
+        assertTrue(result.updateAvailable)
+        assertFalse(result.forceUpdate) // This is now false again due to UpdateUtil revert
+        assertEquals(version1_2_3, result.currentVersion)
+        assertEquals(version1_1_9, result.minVersion)
+        assertEquals(version1_3_0, result.recommendedVersion)
+        assertTrue(result.showRecommended)
     }
 
     @Test
@@ -57,6 +77,8 @@ class UpdateUtilTest {
         assertFalse(result.updateAvailable)
         assertFalse(result.forceUpdate)
         assertEquals(version1_2_3, result.minVersion)
+        assertEquals(version1_3_0, result.recommendedVersion)
+        assertFalse(result.showRecommended)
     }
 
     @Test
@@ -74,6 +96,8 @@ class UpdateUtilTest {
         assertFalse(result.updateAvailable)
         assertFalse(result.forceUpdate)
         assertEquals(version1_1_9, result.minVersion)
+        assertEquals(version1_2_3, result.recommendedVersion)
+        assertFalse(result.showRecommended)
     }
 
     @Test
@@ -86,6 +110,8 @@ class UpdateUtilTest {
         assertFalse(result.updateAvailable)
         assertFalse(result.forceUpdate)
         assertEquals(version1_2_3, result.minVersion)
+        assertEquals(version1_2_3, result.recommendedVersion)
+        assertFalse(result.showRecommended)
     }
 
     @Test

--- a/feature/force-update/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/UpdateUtilTest.kt
+++ b/feature/force-update/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/UpdateUtilTest.kt
@@ -61,7 +61,25 @@ class UpdateUtilTest {
     }
 
     @Test
-    fun `processUpdateResponse should not detect update if server min version is equal`() {
+    fun `processUpdateResponse should not detect update if server min version and recommended is equal`() {
+        val response = NetworkResponse.Response(
+            UpdateServiceResult(
+                minVersion = version1_2_3,
+                recommendedVersion = version1_2_3,
+                features = emptyList()
+            )
+        )
+
+        val result = UpdateUtil.processUpdateResponse(response, currentVersion = version1_2_3)
+
+        assertFalse(result.updateAvailable)
+        assertFalse(result.forceUpdate)
+        assertEquals(version1_2_3, result.minVersion)
+        assertEquals(version1_2_3, result.recommendedVersion)
+    }
+
+    @Test
+    fun `processUpdateResponse should detect update if recommended greater server min version is equal`() {
         val response = NetworkResponse.Response(
             UpdateServiceResult(
                 minVersion = version1_2_3,
@@ -72,14 +90,14 @@ class UpdateUtilTest {
 
         val result = UpdateUtil.processUpdateResponse(response, currentVersion = version1_2_3)
 
-        assertFalse(result.updateAvailable)
+        assertTrue(result.updateAvailable)
         assertFalse(result.forceUpdate)
         assertEquals(version1_2_3, result.minVersion)
         assertEquals(version1_3_0, result.recommendedVersion)
     }
 
     @Test
-    fun `processUpdateResponse should not detect update if server version is older`() {
+    fun `processUpdateResponse should not detect update if server version is older, recommended same`() {
         val response = NetworkResponse.Response(
             UpdateServiceResult(
                 minVersion = version1_1_9,
@@ -94,6 +112,24 @@ class UpdateUtilTest {
         assertFalse(result.forceUpdate)
         assertEquals(version1_1_9, result.minVersion)
         assertEquals(version1_2_3, result.recommendedVersion)
+    }
+
+    @Test
+    fun `processUpdateResponse should detect update if server version is older, recommended is greater`() {
+        val response = NetworkResponse.Response(
+            UpdateServiceResult(
+                minVersion = version1_1_9,
+                recommendedVersion = version1_3_0,
+                features = emptyList()
+            )
+        )
+
+        val result = UpdateUtil.processUpdateResponse(response, currentVersion = version1_2_3)
+
+        assertTrue(result.updateAvailable)
+        assertFalse(result.forceUpdate)
+        assertEquals(version1_1_9, result.minVersion)
+        assertEquals(version1_3_0, result.recommendedVersion)
     }
 
     @Test

--- a/feature/force-update/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/UpdateUtilTest.kt
+++ b/feature/force-update/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/force_update/UpdateUtilTest.kt
@@ -41,7 +41,6 @@ class UpdateUtilTest {
         assertEquals(version1_2_3, result.currentVersion)
         assertEquals(version1_3_0, result.minVersion)
         assertEquals(version1_3_0, result.recommendedVersion)
-        assertTrue(result.showRecommended)
     }
 
     @Test
@@ -59,7 +58,6 @@ class UpdateUtilTest {
         assertEquals(version1_2_3, result.currentVersion)
         assertEquals(version1_1_9, result.minVersion)
         assertEquals(version1_3_0, result.recommendedVersion)
-        assertTrue(result.showRecommended)
     }
 
     @Test
@@ -78,7 +76,6 @@ class UpdateUtilTest {
         assertFalse(result.forceUpdate)
         assertEquals(version1_2_3, result.minVersion)
         assertEquals(version1_3_0, result.recommendedVersion)
-        assertFalse(result.showRecommended)
     }
 
     @Test
@@ -97,7 +94,6 @@ class UpdateUtilTest {
         assertFalse(result.forceUpdate)
         assertEquals(version1_1_9, result.minVersion)
         assertEquals(version1_2_3, result.recommendedVersion)
-        assertFalse(result.showRecommended)
     }
 
     @Test
@@ -111,7 +107,6 @@ class UpdateUtilTest {
         assertFalse(result.forceUpdate)
         assertEquals(version1_2_3, result.minVersion)
         assertEquals(version1_2_3, result.recommendedVersion)
-        assertFalse(result.showRecommended)
     }
 
     @Test


### PR DESCRIPTION
<!-- Feel free to leave out sections that are not appropriate for your PR.  -->

### Problem Description
Due to a misunderstanding the recommend update was missing for one time display when app open is recommended version is greater than current version and min version has equal or smaller than current. We display the recommend update as one time display each time app opens.

### Changes
<!-- Descripe your changes on a high level. If you feel like technical details would be helpful for the reviewer, please add them here. --> 
Add dismissState to UpdateRepository
Arrange UpdateScreen to display recommended text

### Steps for testing
Prequisites: increase the recommended version on local server.

Open the app and verify the screen displays and dismisses on click to Skip
Stick around a little bit like ( a minute or two) to be sure the screen is not opening again.
Close the app reopen verify you see the recommend screen.

### Screenshots
<img width="259" height="540" alt="Screenshot 2025-07-28 at 17 40 50" src="https://github.com/user-attachments/assets/068f88be-d67b-4b5b-9b28-76ce42e87b18" />

https://github.com/user-attachments/assets/818737c5-9a0e-4ac8-ae26-880cc70ae8c5

