### PR TITLE
`Communication`: Prevent unnecessary server requests for forwarded messages

### DIFF
--- a/feature/metis/conversation/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/shared/ui/util/ForwardedMessagesHandler.kt
+++ b/feature/metis/conversation/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/conversation/shared/ui/util/ForwardedMessagesHandler.kt
@@ -45,6 +45,10 @@ class ForwardedMessagesHandler(
      * @param postingType The type of the destination posts for which the forwarded messages should be loaded.
      */
     suspend fun loadForwardedMessages(postingType: PostingType) {
+        if (forwardedPostIds.isEmpty()) {
+            // Do not make a server request if there are no forwarded messages to fetch
+            return
+        }
         metisService.getForwardedMessagesByIds(
             metisContext = metisContext,
             postIds = forwardedPostIds,


### PR DESCRIPTION
### Problem Description
We noticed quite a few logs on the server that look like this:
> Bad Request: Posting IDs cannot be empty when getting forwarded messages.

This error is caused when a request is made to fetch forwarded messages, but no message ids are requested. This is the case when no forwarded messages exist within a channel, thus making the request unnecessary in the first place.

### Changes
We update the function to get forwarded messages by checking if there are any messages to be fetched. If there are none, we don't make a request to the server.


### Steps for testing
- Open conversations with and without forwarded messages
- Ensure forwarded messages are still loaded correctly
- Check server logs to confirm that the above mentioned error log does not occur