### PR TITLE
`Chore`: Remove view quiz result button

### DIFF
--- a/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/exercise/ExerciseActionButtons.kt
+++ b/core/ui/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/ui/exercise/ExerciseActionButtons.kt
@@ -54,10 +54,12 @@ fun ExerciseActionButtons(
     }
 
     if (templateStatus != null) {
-        if (templateStatus is ResultTemplateStatus.WithResult) {
+        // TODO: Quiz results not working, thus disabled
+        if (templateStatus is ResultTemplateStatus.WithResult && exercise !is QuizExercise) {
             ArtemisButton(
                 modifier = modifier,
-                onClick = if (exercise is QuizExercise) actions.onClickViewQuizResults else actions.onClickViewResult,
+                // onClick = if (exercise is QuizExercise) actions.onClickViewQuizResults else actions.onClickViewResult,
+                onClick = actions.onClickViewResult,
                 text = stringResource(id = R.string.exercise_actions_view_result_button)
             )
         }


### PR DESCRIPTION
### Problem Description
Viewing quiz results in the app is currently not working. The server endpoint for it caused issues and didn't work correctly, so it was removed. Thus, we currently cannot show results for quizzes inside the app.


### Changes
For quizzes, we remove the "View result" button.
