### PR TITLE
`Chore`: Use the canonical Artemis API paths

### DIFF
--- a/core/core-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/test/test_setup/course_creation/CourseManagementRequests.kt
+++ b/core/core-test/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/test/test_setup/course_creation/CourseManagementRequests.kt
@@ -90,7 +90,7 @@ suspend fun KoinComponent.createCourse(
     ) {
         url(serverConfigurationService.serverUrl.first())
         url {
-            appendPathSegments(*Api.Core.path, "admin", "courses")
+            appendPathSegments(*Api.Admin.path, "courses")
         }
 
         cookieAuth(accessToken)
@@ -277,12 +277,13 @@ suspend fun KoinComponent.addQuizExerciseBatch(
 
 suspend fun KoinComponent.startQuizExerciseBatch(
     accessToken: String,
-    exerciseId: Long,
     batch: QuizExercise.QuizBatch
 ) {
+    val batchId = requireNotNull(batch.id) { "Cannot start a quiz batch without an id" }
+
     return ktorProvider.ktorClient.put(serverConfigurationService.serverUrl.first()) {
         url {
-            appendPathSegments(*Api.Quiz.QuizExercises.path, exerciseId.toString(), "start-batch")
+            appendPathSegments(*Api.Quiz.QuizBatches.path, batchId.toString(), "start-batch")
         }
 
         setBody(batch)

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
@@ -10,6 +10,11 @@ private const val api = "api"
  * https://github.com/ls1intum/Artemis/pull/10416). To run the app together with a version lower
  * than 8.0.0, remove the first level (module) of the paths (eg. "core", "communication", etc.).
  * (See the git history of this file for the previous version.)
+ *
+ * Artemis 9.3 moved several resources out of the "core" and "communication" modules into modules of
+ * their own: courses answer under "course", the account endpoints under "account", and the push
+ * notification endpoints under "notification". The server still serves the old spellings as
+ * deprecated aliases, but stops doing so on 30 September 2026.
  */
 sealed class Api(
     vararg val path: String
@@ -19,17 +24,21 @@ sealed class Api(
 
     // With 8.0.0 API changes:
 
+    data object Account: Api(api, "account")
+
     data object Core: Api(api, "core") {
         data object Public : Api(*Core.path, "public")
-        data object Courses : Api(*Core.path, "courses")
         data object Files : Api(*Core.path, "files")
         data object Passkey : Api(*Core.path, "passkey")
+    }
+
+    data object Course: Api(api, "course") {
+        data object Courses : Api(*Course.path, "courses")
     }
 
     data object Communication: Api(api, "communication") {
         data object Courses : Api(*Communication.path, "courses")
         data object NotificationSettings : Api(*Communication.path, "notification-settings")
-        data object PushNotification : Api(*Communication.path, "push_notification")
         data object SavedPosts : Api(*Communication.path, "saved-posts")
         data object CourseNotifications : Api(*Communication.path, "notification")
 
@@ -37,6 +46,10 @@ sealed class Api(
         const val standalonePostSegment = "messages"
         /** To be used as a appended path segment after Communication.Courses */
         const val answerPostSegment = "answer-messages"
+    }
+
+    data object Notification: Api(api, "notification") {
+        data object PushNotification : Api(*Notification.path, "push_notification")
     }
 
     data object Lecture: Api(api, "lecture") {
@@ -48,6 +61,7 @@ sealed class Api(
     }
 
     data object Text: Api(api, "text") {
+        data object Participations : Api(*Text.path, "participations")
         data object TextExercises : Api(*Text.path, "text-exercises")
     }
 

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
@@ -12,9 +12,11 @@ private const val api = "api"
  * (See the git history of this file for the previous version.)
  *
  * Artemis 9.3 moved several resources out of the "core" and "communication" modules into modules of
- * their own: courses answer under "course", the account and passkey endpoints under "account", and
- * everything notification-related under "notification". The server still serves the old spellings as
- * deprecated aliases, but stops doing so on 30 September 2026.
+ * their own: courses answer under "course", the account and passkey endpoints under "account",
+ * everything notification-related under "notification", the admin endpoints under "admin" (user
+ * administration under "account/admin"), and starting a quiz batch under "quiz/quiz-batches". The
+ * server still serves the old spellings as deprecated aliases, but stops doing so on
+ * 30 September 2026.
  */
 sealed class Api(
     vararg val path: String
@@ -25,8 +27,11 @@ sealed class Api(
     // With 8.0.0 API changes:
 
     data object Account: Api(api, "account") {
+        data object Admin : Api(*Account.path, "admin")
         data object Passkeys : Api(*Account.path, "passkeys")
     }
+
+    data object Admin: Api(api, "admin")
 
     data object Core: Api(api, "core") {
         data object Public : Api(*Core.path, "public")
@@ -74,6 +79,7 @@ sealed class Api(
     }
 
     data object Quiz: Api(api, "quiz") {
+        data object QuizBatches : Api(*Quiz.path, "quiz-batches")
         data object QuizExercises : Api(*Quiz.path, "quiz-exercises")
     }
 }

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/Api.kt
@@ -12,8 +12,8 @@ private const val api = "api"
  * (See the git history of this file for the previous version.)
  *
  * Artemis 9.3 moved several resources out of the "core" and "communication" modules into modules of
- * their own: courses answer under "course", the account endpoints under "account", and the push
- * notification endpoints under "notification". The server still serves the old spellings as
+ * their own: courses answer under "course", the account and passkey endpoints under "account", and
+ * everything notification-related under "notification". The server still serves the old spellings as
  * deprecated aliases, but stops doing so on 30 September 2026.
  */
 sealed class Api(
@@ -24,12 +24,13 @@ sealed class Api(
 
     // With 8.0.0 API changes:
 
-    data object Account: Api(api, "account")
+    data object Account: Api(api, "account") {
+        data object Passkeys : Api(*Account.path, "passkeys")
+    }
 
     data object Core: Api(api, "core") {
         data object Public : Api(*Core.path, "public")
         data object Files : Api(*Core.path, "files")
-        data object Passkey : Api(*Core.path, "passkey")
     }
 
     data object Course: Api(api, "course") {
@@ -38,9 +39,7 @@ sealed class Api(
 
     data object Communication: Api(api, "communication") {
         data object Courses : Api(*Communication.path, "courses")
-        data object NotificationSettings : Api(*Communication.path, "notification-settings")
         data object SavedPosts : Api(*Communication.path, "saved-posts")
-        data object CourseNotifications : Api(*Communication.path, "notification")
 
         /** To be used as a appended path segment after Communication.Courses */
         const val standalonePostSegment = "messages"
@@ -49,6 +48,7 @@ sealed class Api(
     }
 
     data object Notification: Api(api, "notification") {
+        data object Courses : Api(*Notification.path, "courses")
         data object PushNotification : Api(*Notification.path, "push_notification")
     }
 

--- a/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/network/impl/CourseServiceImpl.kt
+++ b/core/data/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/core/data/service/network/impl/CourseServiceImpl.kt
@@ -19,7 +19,7 @@ internal class CourseServiceImpl(
     ): NetworkResponse<CourseWithScore> {
         return getRequest {
             url {
-                appendPathSegments(*Api.Core.Courses.path, courseId.toString(), "for-dashboard")
+                appendPathSegments(*Api.Course.Courses.path, courseId.toString(), "for-dashboard")
             }
         }
     }

--- a/docker/create_test_users.sh
+++ b/docker/create_test_users.sh
@@ -17,7 +17,7 @@ adminJwt=${BASH_REMATCH[1]}
 
 for i in 1 2 3
 do
-  curl -X POST http://"$serverUrl"/api/core/admin/users \
+  curl -X POST http://"$serverUrl"/api/account/admin/users \
   -H "Content-Type: application/json" \
   -H "Cookie: jwt=${adminJwt};" \
   -d '{"authorities":["ROLE_USER"],"login":"aa0'${i}'aaa","email":"test_user'${i}'@example.com","firstName":"Test","lastName":"User'${i}'","guidedTourSettings":[],"groups":["default"],"password":"test_user_'${i}'_password"}'

--- a/feature/course-notifications/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/coursenotifications/service/impl/CourseNotificationSettingsServiceImpl.kt
+++ b/feature/course-notifications/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/coursenotifications/service/impl/CourseNotificationSettingsServiceImpl.kt
@@ -25,7 +25,7 @@ class CourseNotificationSettingsServiceImpl(
     override suspend fun getNotificationSettingsInfo(): NetworkResponse<NotificationSettingsInfo> {
         return getRequest {
             url {
-                appendPathSegments(*Api.Communication.CourseNotifications.path, "info")
+                appendPathSegments(*Api.Notification.Courses.path, "info")
             }
             Log.d(TAG, "Fetching notification settings info from $url")
         }
@@ -37,7 +37,7 @@ class CourseNotificationSettingsServiceImpl(
         return getRequest {
             url {
                 appendPathSegments(
-                    *Api.Communication.CourseNotifications.path,
+                    *Api.Notification.Courses.path,
                     courseId.toString(),
                     "settings"
                 )
@@ -54,7 +54,7 @@ class CourseNotificationSettingsServiceImpl(
         return putRequest {
             url {
                 appendPathSegments(
-                    *Api.Communication.CourseNotifications.path,
+                    *Api.Notification.Courses.path,
                     courseId.toString(),
                     "setting-specification"
                 )
@@ -76,7 +76,7 @@ class CourseNotificationSettingsServiceImpl(
         return putRequest {
             url {
                 appendPathSegments(
-                    *Api.Communication.CourseNotifications.path,
+                    *Api.Notification.Courses.path,
                     courseId.toString(),
                     "setting-preset"
                 )

--- a/feature/course-registration/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseregistration/service/impl/CourseRegistrationServiceImpl.kt
+++ b/feature/course-registration/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/courseregistration/service/impl/CourseRegistrationServiceImpl.kt
@@ -18,7 +18,7 @@ internal class CourseRegistrationServiceImpl(
     override suspend fun fetchRegistrableCourses(): NetworkResponse<List<Course>> {
         return getRequest {
             url {
-                appendPathSegments(*Api.Core.Courses.path, "for-enrollment")
+                appendPathSegments(*Api.Course.Courses.path, "for-enrollment")
             }
         }
     }
@@ -26,7 +26,7 @@ internal class CourseRegistrationServiceImpl(
     override suspend fun registerInCourse(courseId: Long): NetworkResponse<HttpStatusCode> {
         return postRequest {
             url {
-                appendPathSegments(*Api.Core.Courses.path, courseId.toString(), "enroll")
+                appendPathSegments(*Api.Course.Courses.path, courseId.toString(), "enroll")
             }
         }
     }

--- a/feature/dashboard/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/dashboard/service/impl/DashboardServiceImpl.kt
+++ b/feature/dashboard/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/dashboard/service/impl/DashboardServiceImpl.kt
@@ -20,7 +20,7 @@ internal class DashboardServiceImpl(
     override suspend fun loadDashboard(): NetworkResponse<Dashboard> {
         return getRequest {
             url {
-                appendPathSegments(*Api.Core.Courses.path, "for-dashboard")
+                appendPathSegments(*Api.Course.Courses.path, "for-dashboard")
             }
         }
     }

--- a/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/service/impl/TextEditorServiceImpl.kt
+++ b/feature/exercise-view/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/exerciseview/service/impl/TextEditorServiceImpl.kt
@@ -17,7 +17,7 @@ class TextEditorServiceImpl(
     override suspend fun getParticipation(participationId: Long): NetworkResponse<Participation> {
         return getRequest {
             url {
-                appendPathSegments(*Api.Text.path, "text-editor", participationId.toString())
+                appendPathSegments(*Api.Text.Participations.path, participationId.toString(), "text-editor")
             }
         }
     }

--- a/feature/login/src/test/java/de/tum/informatics/www1/artemis/native_app/feature/login/RegisterEndToEndTest.kt
+++ b/feature/login/src/test/java/de/tum/informatics/www1/artemis/native_app/feature/login/RegisterEndToEndTest.kt
@@ -125,7 +125,7 @@ class RegisterEndToEndTest : BaseComposeTest() {
     private suspend fun getUsers(loginName: String): List<User> {
         return ktorProvider.ktorClient.get(testServerUrl) {
             url {
-                appendPathSegments(*Api.Core.path, "admin", "users")
+                appendPathSegments(*Api.Account.Admin.path, "users")
 
                 parameter("page", 0)
                 parameter("pageSize", 10)

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
@@ -101,6 +101,35 @@ class ConversationServiceImpl(private val ktorProvider: KtorProvider) : Conversa
         partner: String,
         authToken: String,
         serverUrl: String
+    ): NetworkResponse<OneToOneChat> = createOneToOneConversation(
+        courseId = courseId,
+        chatPartner = OneToOneChatPartner(login = partner),
+        authToken = authToken,
+        serverUrl = serverUrl
+    )
+
+    override suspend fun createOneToOneConversation(
+        courseId: Long,
+        partnerId: Long,
+        authToken: String,
+        serverUrl: String
+    ): NetworkResponse<OneToOneChat> = createOneToOneConversation(
+        courseId = courseId,
+        chatPartner = OneToOneChatPartner(userId = partnerId),
+        authToken = authToken,
+        serverUrl = serverUrl
+    )
+
+    /**
+     * Creates the one-to-one chat with the given partner. The partner is identified in the request
+     * body; the deprecated variant that appends the partner id as a path segment stops being served
+     * on 30 September 2026.
+     */
+    private suspend fun createOneToOneConversation(
+        courseId: Long,
+        chatPartner: OneToOneChatPartner,
+        authToken: String,
+        serverUrl: String
     ): NetworkResponse<OneToOneChat> {
         return performNetworkCall {
             ktorProvider.ktorClient.post(serverUrl) {
@@ -108,7 +137,7 @@ class ConversationServiceImpl(private val ktorProvider: KtorProvider) : Conversa
                     appendPathSegments(*Api.Communication.Courses.path, courseId.toString(), "one-to-one-chats")
                 }
 
-                setBody(listOf(partner))
+                setBody(chatPartner)
                 contentType(ContentType.Application.Json)
 
                 accept(ContentType.Application.Json)
@@ -117,23 +146,15 @@ class ConversationServiceImpl(private val ktorProvider: KtorProvider) : Conversa
         }
     }
 
-    override suspend fun createOneToOneConversation(
-        courseId: Long,
-        partnerId: Long,
-        authToken: String,
-        serverUrl: String
-    ): NetworkResponse<OneToOneChat> {
-        return performNetworkCall {
-            ktorProvider.ktorClient.post(serverUrl) {
-                url {
-                    appendPathSegments(*Api.Communication.Courses.path, courseId.toString(), "one-to-one-chats", partnerId.toString())
-                }
-
-                accept(ContentType.Application.Json)
-                cookieAuth(authToken)
-            }.body()
-        }
-    }
+    /**
+     * The single other participant of a one-to-one chat, identified by exactly one of [userId] or
+     * [login]. The unset one is left out of the request body.
+     */
+    @Serializable
+    private data class OneToOneChatPartner(
+        val userId: Long? = null,
+        val login: String? = null
+    )
 
     override suspend fun createChannel(
         courseId: Long,

--- a/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
+++ b/feature/metis/shared/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/metis/shared/service/network/impl/ConversationServiceImpl.kt
@@ -64,7 +64,7 @@ class ConversationServiceImpl(private val ktorProvider: KtorProvider) : Conversa
         return performNetworkCall {
             ktorProvider.ktorClient.get(serverUrl) {
                 url {
-                    appendPathSegments(*Api.Core.Courses.path, courseId.toString(), "users", "search")
+                    appendPathSegments(*Api.Course.Courses.path, courseId.toString(), "users", "search")
 
                     parameter("loginOrName", query)
                     parameter("roles", roles.joinToString(","))

--- a/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/network/impl/NotificationSettingsServiceImpl.kt
+++ b/feature/push/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/push/service/network/impl/NotificationSettingsServiceImpl.kt
@@ -32,7 +32,7 @@ internal class NotificationSettingsServiceImpl(private val ktorProvider: KtorPro
         return performNetworkCall {
             val response: RegisterResponseBody = ktorProvider.ktorClient.post(serverUrl) {
                 url {
-                    appendPathSegments(*Api.Communication.PushNotification.path, "register")
+                    appendPathSegments(*Api.Notification.PushNotification.path, "register")
                 }
 
                 cookieAuth(authToken)
@@ -61,7 +61,7 @@ internal class NotificationSettingsServiceImpl(private val ktorProvider: KtorPro
         return performNetworkCall {
             ktorProvider.ktorClient.delete(serverUrl) {
                 url {
-                    appendPathSegments(*Api.Communication.PushNotification.path, "unregister")
+                    appendPathSegments(*Api.Notification.PushNotification.path, "unregister")
                 }
 
                 cookieAuth(authToken)

--- a/feature/quiz/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/quiz/QuizWaitingScreenE2eTest.kt
+++ b/feature/quiz/src/test/kotlin/de/tum/informatics/www1/artemis/native_app/feature/quiz/QuizWaitingScreenE2eTest.kt
@@ -150,7 +150,7 @@ internal class QuizWaitingScreenE2eTest : QuizBaseE2eTest(QuizType.Live) {
 
         // Start the batch to generate a participation
         runBlockingWithTestTimeout {
-            startQuizExerciseBatch(getAdminAccessToken(), quiz.id, batch)
+            startQuizExerciseBatch(getAdminAccessToken(), batch)
         }
 
         val participation = runBlockingWithTestTimeout {

--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/service/impl/ChangeProfilePictureServiceImpl.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/service/impl/ChangeProfilePictureServiceImpl.kt
@@ -32,8 +32,7 @@ class ChangeProfilePictureServiceImpl(
         return putRequest {
             url {
                 appendPathSegments(
-                    *Api.Core.path,
-                    "account",
+                    *Api.Account.path,
                     "profile-picture",
                 )
             }
@@ -55,8 +54,7 @@ class ChangeProfilePictureServiceImpl(
         return deleteRequest {
             url {
                 appendPathSegments(
-                    *Api.Core.path,
-                    "account",
+                    *Api.Account.path,
                     "profile-picture",
                 )
             }

--- a/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/service/impl/PasskeySettingsServiceImpl.kt
+++ b/feature/settings/src/main/kotlin/de/tum/informatics/www1/artemis/native_app/feature/settings/service/impl/PasskeySettingsServiceImpl.kt
@@ -23,7 +23,7 @@ class PasskeySettingsServiceImpl(
     override suspend fun getPasskeys(): NetworkResponse<List<PasskeyDTO>> {
         return getRequest {
             url {
-                appendPathSegments(*Api.Core.Passkey.path, "user")
+                appendPathSegments(*Api.Account.Passkeys.path, "user")
             }
         }
     }


### PR DESCRIPTION
### Problem Description

Sixteen endpoints the app calls are reached through a legacy alias of the Artemis server, and four more calls in the test setup are. The server tags those responses with `Deprecation` and `Sunset` headers and the aliases stop responding on **30 September 2026**, after which course enrollment, the dashboard, the member search, starting a one-to-one chat, push notification registration, the notification settings screen, the passkey list, the profile picture upload and the text exercise editor all break, and the instrumented suite can no longer create its courses and users.

### Changes

Almost all of it is a change to the central `Api` registry rather than to the call sites, because every request is built from it with `appendPathSegments`. Four module objects are new (`Api.Account`, `Api.Admin`, `Api.Course`, `Api.Notification`) and `Api.Core` keeps only what the core module still canonically serves.

The paths the audit of the server's deprecated APIs turned up:

| Before | After | Call site |
|---|---|---|
| `GET api/core/courses/for-dashboard` | `GET api/course/courses/for-dashboard` | `DashboardServiceImpl` |
| `GET api/core/courses/{courseId}/for-dashboard` | `GET api/course/courses/{courseId}/for-dashboard` | `CourseServiceImpl` |
| `GET api/core/courses/for-enrollment` | `GET api/course/courses/for-enrollment` | `CourseRegistrationServiceImpl` |
| `POST api/core/courses/{courseId}/enroll` | `POST api/course/courses/{courseId}/enroll` | `CourseRegistrationServiceImpl` |
| `GET api/core/courses/{courseId}/users/search` | `GET api/course/courses/{courseId}/users/search` | `ConversationServiceImpl` |
| `POST api/communication/push_notification/register` | `POST api/notification/push_notification/register` | `NotificationSettingsServiceImpl` |
| `DELETE api/communication/push_notification/unregister` | `DELETE api/notification/push_notification/unregister` | `NotificationSettingsServiceImpl` |
| `PUT api/core/account/profile-picture` | `PUT api/account/profile-picture` | `ChangeProfilePictureServiceImpl` |
| `DELETE api/core/account/profile-picture` | `DELETE api/account/profile-picture` | `ChangeProfilePictureServiceImpl` |
| `GET api/text/text-editor/{participationId}` | `GET api/text/participations/{participationId}/text-editor` | `TextEditorServiceImpl` |

Two more groups turned up while making that change and are in a separate commit so they can be dropped on their own:

| Before | After | Call site |
|---|---|---|
| `GET api/core/passkey/user` | `GET api/account/passkeys/user` | `PasskeySettingsServiceImpl` |
| `GET api/communication/notification/info` | `GET api/notification/courses/info` | `CourseNotificationSettingsServiceImpl` |
| `GET api/communication/notification/{courseId}/settings` | `GET api/notification/courses/{courseId}/settings` | `CourseNotificationSettingsServiceImpl` |
| `PUT api/communication/notification/{courseId}/setting-specification` | `PUT api/notification/courses/{courseId}/setting-specification` | `CourseNotificationSettingsServiceImpl` |
| `PUT api/communication/notification/{courseId}/setting-preset` | `PUT api/notification/courses/{courseId}/setting-preset` | `CourseNotificationSettingsServiceImpl` |

`PasskeyResource` is mapped `@RequestMapping({ "api/account/passkeys/", "api/account/passkey/", AccountLegacyRestPaths.CORE_PASSKEY_PREFIX })`, and `CourseNotificationResource`, `UserCourseNotificationSettingResource` and `UserCourseNotificationStatusResource` are each mapped `@RequestMapping({ "api/notification/courses/", NotificationLegacyRestPaths.COMMUNICATION_NOTIFICATION_PREFIX })`. In that convention the first entry is canonical and every later one is a legacy alias on the same sunset date. The iOS app already asks for the canonical notification paths.

That commit also drops `Api.Communication.NotificationSettings`: nothing referenced it, and `api/communication/notification-settings` is not an endpoint the server has.

Request and response shapes are unchanged for all of the above. The `webauthn/...` and `login/webauthn` paths are Spring Security endpoints outside `api/`, so they are unaffected.

#### Starting a one-to-one chat

`ConversationServiceImpl` has two overloads of `createOneToOneConversation`, one taking a login and one taking a user id. The one taking a user id appended it to the URL:

```
POST api/communication/courses/{courseId}/one-to-one-chats/{userId}
```

`OneToOneChatResource.startOneToOneChat` is mapped `@PostMapping({ "{courseId}/one-to-one-chats", "{courseId}/one-to-one-chats/{userId}" })`, so that spelling is the legacy alias. On the canonical route the partner is identified in the request body, by an `OneToOneChatCreationDTO` holding exactly one of `userId` or `login`:

```
POST api/communication/courses/{courseId}/one-to-one-chats
{"userId": 42}          or          {"login": "ab12cde"}
```

The server resolves the partner in the order path id, body `userId`, body `login`, and answers 400 `missingPartner` when none of the three is present. The web client posts the same two object bodies from `one-to-one-chat.service.ts`.

Both overloads now build that body and share one request builder, so the id variant no longer touches the path and the login variant no longer sends the deprecated single-login array (`["ab12cde"]`). `OneToOneChatCreationDTO` still accepts that array through a custom deserializer, and names the Android app as one of the reasons the branch is kept, so this removes the last reason to keep it. The two callers of the id overload, `ForwardMessageUseCase` and `NavigateToUserConversationViewModel`, are unchanged: the interface they call still takes a `Long` and a `UserIdentifier.UserId` respectively.

#### Test setup and tooling

These are not shipped app code, but they live in this repository and stop working on the same date, so they are migrated here rather than left for a follow-up:

| Before | After | Call site |
|---|---|---|
| `POST api/core/admin/courses` | `POST api/admin/courses` | `CourseManagementRequests.createCourse` |
| `GET api/core/admin/users` | `GET api/account/admin/users` | `RegisterEndToEndTest.getUsers` |
| `POST api/core/admin/users` | `POST api/account/admin/users` | `docker/create_test_users.sh` |
| `PUT api/quiz/quiz-exercises/{quizBatchId}/start-batch` | `PUT api/quiz/quiz-batches/{quizBatchId}/start-batch` | `CourseManagementRequests.startQuizExerciseBatch` |

User administration is the one part of the admin API that did not move to `api/admin`: `AdminUserResource` is mapped `@RequestMapping({ "api/account/admin/", AccountLegacyRestPaths.CORE_ADMIN_PREFIX })`, so its canonical prefix is `api/account/admin`, while `AdminCourseResource` is mapped `@RequestMapping({ "api/admin/", LegacyAdminRestPaths.CORE_ADMIN_PREFIX })`.

Starting a quiz batch changes shape rather than only prefix, because `startBatch` takes a quiz batch id, not a quiz exercise id. The helper was passing the quiz exercise id into that position, which resolved no batch on either spelling of the path, so it now derives the id from the batch it is handed and the caller no longer passes the exercise id. The two tests that exercise this are `@Ignore`d on issue #107, which is why the wrong id went unnoticed.

### Not touched

**File URLs the server hands us.** The app also requests these legacy spellings, but it does not choose them: the server writes them into `course.courseIcon`, `user.imageUrl`, `attachment.link` and `dragAndDropQuestion.backgroundFilePath` (`FilePathConverter.externalUriForFileSystemPath`), and `ArtemisImageProviderImpl` and `AttachmentUtil` append whatever they were given. They can only be retired server-side, by changing what is emitted and canonicalizing the values already persisted:

- `api/core/files/course/icons/{courseId}/*`
- `api/core/files/user/profile-pictures/{userId}/*`
- `api/core/files/drag-and-drop/backgrounds/{questionId}/*`
- `api/core/files/attachments/lecture/{lectureId}/{attachmentName}`
- `api/core/files/attachments/attachment-unit/{attachmentVideoUnitId}/*`, and its `/student/*` and `/slide/{slideNumber}` variants

No client-side rewriting of those links is added here. `api/core/files/...` itself is not legacy: `api/core/` is the canonical prefix of `FileResource`.

### Known issues, not fixed here

**Drag-item images in quizzes** are broken today, independently of this change. The server emits `drag-and-drop/drag-items/{dragItemId}/{filename}` into `dragItem.pictureFilePath` and `DragItemUi` appends it to `api/core/files`, but `FileResource` only maps `files/drag-and-drop/questions/{questionId}/drag-items/{dragItemId}/*`. There is no alias for the shorter form in either spelling, so the request 404s. The iOS app papers over it with a client-side string replacement. The fix belongs on the server, in what `FilePathConverter` emits, so no workaround is added here.

**Server time synchronization** has been failing silently since Artemis 8.8.2 (released 22 February 2026). `ServerTimeServiceImpl` requests `api/core/public/time`, which `PublicTimeResource` served until ls1intum/Artemis#12078 deleted that class and replaced it with a Tomcat valve answering `/api/public/time`, with no alias for the old path. So this one is not a deprecated alias but an endpoint that is already gone, and the app falls back to the device clock after three failed attempts. Fixing it is more than a path change: the valve answers `text/plain` with a bare ISO instant, so the response has to be read as text and parsed, the way `ServerDateService` does on the web. It is left out of this pull request to keep the change reviewable, and needs its own testing against a live server.

### Steps for testing

1. Open the dashboard and confirm the course list, scores and exercises load.
2. Open **Register for course**, confirm the enrollable courses load, and enroll in one.
3. Open a channel, invite a member, and confirm the user search returns results.
4. Tap the profile picture of a message author you have never messaged, choose **Send message** in the profile dialog, and confirm a one-to-one chat with that user is created and opens. This is the path that used to carry the partner id in the URL.
5. Forward a message to a single recipient you have no chat with yet, and confirm it arrives in a new one-to-one chat.
6. Tap an `@mention` of a user you have never messaged and confirm the chat opens as well. This is the login variant of the same request.
7. Start a personal conversation from the member search and confirm it is created.
8. Toggle push notifications off and on in the settings and confirm no error is shown, then send yourself a message from another account and confirm the notification arrives.
9. Open a course's notification settings, switch the preset, and change one individual setting.
10. Open **Settings**, change the profile picture, then remove it again.
11. Open the passkey settings and confirm the existing passkeys are listed.
12. Open a text exercise with a participation and confirm the previous submission loads in the editor.

### Screenshots

Not applicable: no user-visible change, only the request URLs and the body of one request.

### Context

Found while auditing the Artemis server's deprecated API paths. The other clients have their own pull requests: ls1intum/artemis-ios#528, ls1intum/artemis-ios-core-modules#203 and ls1intum/artemis-extension#463.

Verified with the two tasks CI compiles with, `compileProductionUnrestrictedReleaseSources` and `compileProductionUnrestrictedReleaseUnitTestSources`, and with the unit test suite as CI runs it (`./gradlew test -Dskip.unit-tests=false -Dskip.e2e=true -Dskip.debugVariants=true -Dskip.flavor.unrestricted=true -Dskip.flavor.beta=true`): 149 tests, no failures, one skipped. The serialized one-to-one chat body was checked against the app's own `Json` configuration, which has `explicitNulls = false` and therefore leaves the unset identifier out, giving `{"userId":42}` and `{"login":"ab12cde"}`. The instrumented suite needs a live Artemis server and was not run.

### Server requirement

The canonical paths landed in Artemis 9.4 (released 11 June 2026), through ls1intum/Artemis#12811, #12813 and #12822, so a release carrying this change needs the instances it talks to to run 9.4 or newer. That is the same bar the legacy aliases set from the other side: they stop responding on 30 September 2026. The one exception is `api/admin/courses`, which the server has answered since 2022.
